### PR TITLE
refactor for plugin to be more secure and extendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-03-10
+
+### Changed
+
+- Refactored `fetch.lua` into smaller, focused helper functions (`run_az_command`, `prompt`, `decrypt_settings`, `build_local_settings`, `write_settings`)
+- Fixed shell injection vulnerability by applying `vim.fn.shellescape()` to all user inputs passed to Azure CLI
+- Fixed path injection in `vim.cmd("edit ...")` by using `vim.fn.fnameescape()`
+- Replaced all `print()` calls with `vim.notify()` using appropriate log levels
+- Removed duplicate JSON encoding — now consistently uses `vim.json.encode()`
+- Replaced `vim.api.nvim_set_keymap()` with `vim.keymap.set()` in `init.lua`
+- Config is now passed as a table to `fetch_app_settings()` instead of loose booleans
+- Added `desc` to keymap and user command (visible in `:map` and `which-key`)
+
+### Added
+
+- `key_vault_name` config option (required when `decrypt = true`)
+- `output_path` config option to set a custom output directory
+- `open_file` config option to control whether the file opens after saving (default: `true`)
+- Helpful error tip when Azure CLI fails: suggests running `az login`
+
 ## [0.1.3] - 2025-04-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `key_vault_name` config option (optional, used when `decrypt = true`)
+- `key_vault_name` config option (optional, used when `decrypt = true` and settings contain `ENC(...)` values)
+- Smart secret name resolution for `ENC(...)` values: uses the content inside `ENC(...)` if it is a valid Key Vault secret name, otherwise falls back to the app setting name
 - `output_path` config option to set a custom output directory
 - `open_file` config option to control whether the file opens after saving (default: `true`)
 - Helpful error tip when Azure CLI fails: suggests running `az login`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `key_vault_name` config option (required when `decrypt = true`)
+- `key_vault_name` config option (optional, used when `decrypt = true`)
 - `output_path` config option to set a custom output directory
 - `open_file` config option to control whether the file opens after saving (default: `true`)
 - Helpful error tip when Azure CLI fails: suggests running `az login`

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ You can install `azure.nvim` using your favorite plugin manager. Here's how:
 ```lua
 require("lazy").setup({
     {
-        "edwinboon/azure.nvim", -- Replace with your GitHub repository URL
-        version = "v0.1.0", -- Pin to a specific version
+        "edwinboon/azure.nvim",
+        version = "v0.2.0", -- Pin to a specific version
         config = function()
             require("azure").setup({
                 decrypt = true, -- Enable decryption
@@ -51,8 +51,8 @@ require("lazy").setup({
 
 ```lua
 use {
-    "edwinboon/azure.nvim", -- Replace with your GitHub repository URL
-    tag = "v0.1.0", -- Pin to a specific version
+    "edwinboon/azure.nvim",
+    tag = "v0.2.0", -- Pin to a specific version
     config = function()
         require("azure").setup({
             decrypt = true, -- Enable decryption

--- a/README.md
+++ b/README.md
@@ -4,29 +4,30 @@ A Neovim plugin to fetch and optionally decrypt Azure Function App settings dire
 
 ## Features
 
-- Fetch settings from an Azure Function App.
-- Optionally decrypt the settings after fetching.
+- Fetch settings from an Azure Function App and save them as `local.settings.json`.
+- Optionally decrypt `ENC(...)` values using Azure Key Vault.
 - Dynamic resource group handling for each fetch operation.
 - Configurable keybindings and commands.
+- Configurable output path and file-open behavior.
 
 ---
 
 ## Prerequisites
 
-Before using this plugin, make sure you have the following tools installed and configured:
+Before using this plugin, make sure you have the following installed and configured:
 
 1. **[Azure CLI](https://learn.microsoft.com/en-us/cli/azure/):**
    - Required for fetching and decrypting Azure Function App settings.
-   - Ensure you are logged in using `az login`:
+   - Ensure you are logged in:
      ```bash
      az login
      ```
 
+2. **Neovim 0.7+**
+
 ---
 
 ## Installation
-
-You can install `azure.nvim` using your favorite plugin manager. Here's how:
 
 ### Using [lazy.nvim](https://github.com/folke/lazy.nvim):
 
@@ -34,12 +35,11 @@ You can install `azure.nvim` using your favorite plugin manager. Here's how:
 require("lazy").setup({
     {
         "edwinboon/azure.nvim",
-        version = "v0.2.0", -- Pin to a specific version
+        version = "v0.2.0",
         config = function()
             require("azure").setup({
-                decrypt = true, -- Enable decryption
                 keymaps = {
-                    fetch_app_settings = "<leader>af", -- Custom keybinding for fetching app settings
+                    fetch_app_settings = "<leader>af",
                 },
             })
         end,
@@ -52,12 +52,11 @@ require("lazy").setup({
 ```lua
 use {
     "edwinboon/azure.nvim",
-    tag = "v0.2.0", -- Pin to a specific version
+    tag = "v0.2.0",
     config = function()
         require("azure").setup({
-            decrypt = true, -- Enable decryption
             keymaps = {
-                fetch_app_settings = "<leader>af", -- Custom keybinding for fetching app settings
+                fetch_app_settings = "<leader>af",
             },
         })
     end,
@@ -68,53 +67,99 @@ use {
 
 ## Usage
 
-1. **Keybinding**:
+1. **Keybinding**: Press the configured keybinding (default: `<leader>af`) in normal mode.
+2. **Command**: Run `:AzFetchAppSettings`.
 
-   - Press the configured keybinding (default: `<leader>af`) in normal mode.
-   - Enter the name of the Azure Function App when prompted.
-   - Enter the name of the Azure Resource Group when prompted.
-   - The settings will be fetched, and optionally decrypted if `decrypt` is enabled.
-
-2. **Command**:
-   - Alternatively, you can use the command `:AzFetchAppSettings` to fetch the settings.
-   - This is useful if you prefer not to use keybindings.
+You will be prompted for the Function App name and Resource Group. The settings will be fetched and saved as `local.settings.json` in the current working directory (or `output_path` if configured).
 
 ---
 
 ## Configuration Options
 
-| Option            | Type    | Default | Description                                                                 |
-| ----------------- | ------- | ------- | --------------------------------------------------------------------------- |
-| `decrypt`         | boolean | `false` | Whether to decrypt `ENC(...)` values after fetching.                        |
-| `key_vault_name`  | string  | `nil`   | Azure Key Vault name used for decryption (optional, only used with `decrypt = true`). |
-| `output_path`     | string  | `nil`   | Directory to write `local.settings.json` to. Defaults to current working directory. |
-| `open_file`       | boolean | `true`  | Whether to open `local.settings.json` in the editor after saving.           |
-| `keymaps`         | table   | `{}`    | Table of keybindings for specific plugin actions.                           |
+| Option           | Type    | Default | Description                                                                        |
+| ---------------- | ------- | ------- | ---------------------------------------------------------------------------------- |
+| `decrypt`        | boolean | `false` | Attempt to decrypt `ENC(...)` values after fetching.                               |
+| `key_vault_name` | string  | `nil`   | Azure Key Vault name used for decryption. Required when settings contain `ENC(...)` values. |
+| `output_path`    | string  | `nil`   | Directory to write `local.settings.json` to. Defaults to current working directory. |
+| `open_file`      | boolean | `true`  | Whether to open `local.settings.json` in the editor after saving.                  |
+| `keymaps`        | table   | `{}`    | Table of keybindings for plugin actions.                                           |
 
 ### Keymaps Table
 
-The `keymaps` table allows you to define custom keybindings for specific plugin functions:
+| Key                  | Default       | Description                                        |
+| -------------------- | ------------- | -------------------------------------------------- |
+| `fetch_app_settings` | `<leader>af`  | Fetch and optionally decrypt Function App settings. |
 
-| Key                  | Description                                              |
-| -------------------- | -------------------------------------------------------- |
-| `fetch_app_settings` | Keybinding to fetch and optionally decrypt app settings. |
+---
+
+## Decryption
+
+When `decrypt = true`, the plugin will look for settings whose value starts with `ENC(...)` and attempt to retrieve the plaintext value from Azure Key Vault.
+
+The secret name is resolved as follows:
+- If the content inside `ENC(...)` is a valid Key Vault secret name (letters, numbers, hyphens), that name is used.
+- Otherwise, the app setting name is used as the secret name.
+
+**Examples:**
+
+| App setting value       | Secret name used in Key Vault |
+| ----------------------- | ----------------------------- |
+| `ENC(my-secret-name)`   | `my-secret-name`              |
+| `ENC(<encrypted-blob>)` | the app setting name          |
+
+**Example configuration with decryption:**
+
+```lua
+require("azure").setup({
+    decrypt = true,
+    key_vault_name = "my-keyvault",
+    keymaps = {
+        fetch_app_settings = "<leader>af",
+    },
+})
+```
 
 ---
 
 ## Example Configuration
 
-Here's a sample configuration for your `init.lua`:
+Minimal setup:
 
 ```lua
 require("azure").setup({
-    decrypt = true, -- Enable decryption after fetching
     keymaps = {
-        fetch_app_settings = "<leader>af", -- Set a custom keybinding for fetching app settings
+        fetch_app_settings = "<leader>af",
     },
 })
 ```
 
-If you prefer using commands, you can skip the `keymaps` option and use `:AzFetchAppSettings` instead.
+Full configuration:
+
+```lua
+require("azure").setup({
+    decrypt = true,
+    key_vault_name = "my-keyvault",
+    output_path = "/path/to/project",
+    open_file = true,
+    keymaps = {
+        fetch_app_settings = "<leader>af",
+    },
+})
+```
+
+If you prefer commands over keybindings, skip the `keymaps` option and use `:AzFetchAppSettings` instead.
+
+---
+
+## Troubleshooting
+
+**Error fetching settings**
+- Make sure you are logged in with `az login`.
+- Verify the Function App name and Resource Group are correct.
+
+**Decryption fails**
+- Make sure `key_vault_name` is set in your config.
+- Ensure you have read access to the Key Vault secrets.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,13 @@ use {
 
 ## Configuration Options
 
-| Option    | Type    | Default | Description                                       |
-| --------- | ------- | ------- | ------------------------------------------------- |
-| `decrypt` | boolean | `false` | Whether to decrypt settings after fetching.       |
-| `keymaps` | table   | `{}`    | Table of keybindings for specific plugin actions. |
+| Option            | Type    | Default | Description                                                                 |
+| ----------------- | ------- | ------- | --------------------------------------------------------------------------- |
+| `decrypt`         | boolean | `false` | Whether to decrypt `ENC(...)` values after fetching.                        |
+| `key_vault_name`  | string  | `nil`   | Azure Key Vault name used for decryption (optional, only used with `decrypt = true`). |
+| `output_path`     | string  | `nil`   | Directory to write `local.settings.json` to. Defaults to current working directory. |
+| `open_file`       | boolean | `true`  | Whether to open `local.settings.json` in the editor after saving.           |
+| `keymaps`         | table   | `{}`    | Table of keybindings for specific plugin actions.                           |
 
 ### Keymaps Table
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You will be prompted for the Function App name and Resource Group. The settings 
 | Option           | Type    | Default | Description                                                                        |
 | ---------------- | ------- | ------- | ---------------------------------------------------------------------------------- |
 | `decrypt`        | boolean | `false` | Attempt to decrypt `ENC(...)` values after fetching.                               |
-| `key_vault_name` | string  | `nil`   | Azure Key Vault name used for decryption. Required when settings contain `ENC(...)` values. |
+| `key_vault_name` | string  | `nil`   | Azure Key Vault name used for decryption. Required when `decrypt = true` and settings contain `ENC(...)` values. |
 | `output_path`    | string  | `nil`   | Directory to write `local.settings.json` to. Defaults to current working directory. |
 | `open_file`      | boolean | `true`  | Whether to open `local.settings.json` in the editor after saving.                  |
 | `keymaps`        | table   | `{}`    | Table of keybindings for plugin actions.                                           |

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -1,8 +1,9 @@
 local M = {}
 
--- Run an Azure CLI command and return the output, or nil on error
+-- Run an Azure CLI command and return the output, or nil on error.
+-- stderr is redirected to stdout so error messages are always captured.
 local function run_az_command(cmd)
-	local result = vim.fn.system(cmd)
+	local result = vim.fn.system(cmd .. " 2>&1")
 	if vim.v.shell_error ~= 0 then
 		return nil, result
 	end
@@ -31,30 +32,39 @@ end
 
 -- Decrypt any ENC(...) values by fetching them from Key Vault
 local function decrypt_settings(settings, vault_name)
+	if not vault_name then
+		local enc_count = 0
+		for _, setting in ipairs(settings) do
+			if type(setting.value) == "string" and setting.value:match("^ENC%(") then
+				enc_count = enc_count + 1
+			end
+		end
+		if enc_count > 0 then
+			vim.notify(
+				"Skipping decryption of " .. enc_count .. " ENC(...) value(s): key_vault_name is not configured.",
+				vim.log.levels.WARN
+			)
+		end
+		return
+	end
+
 	for _, setting in ipairs(settings) do
 		if type(setting.value) == "string" and setting.value:match("^ENC%(") then
-			if not vault_name then
+			local secret_name = resolve_secret_name(setting.name, setting.value)
+			local cmd = "az keyvault secret show --name "
+				.. vim.fn.shellescape(secret_name)
+				.. " --vault-name "
+				.. vim.fn.shellescape(vault_name)
+				.. " --query value -o tsv"
+
+			local decrypted, err = run_az_command(cmd)
+			if decrypted then
+				setting.value = vim.trim(decrypted)
+			else
 				vim.notify(
-					"Skipping decryption of '" .. setting.name .. "': key_vault_name is not configured.",
+					"Failed to decrypt '" .. setting.name .. "': " .. err,
 					vim.log.levels.WARN
 				)
-			else
-				local secret_name = resolve_secret_name(setting.name, setting.value)
-				local cmd = "az keyvault secret show --name "
-					.. vim.fn.shellescape(secret_name)
-					.. " --vault-name "
-					.. vim.fn.shellescape(vault_name)
-					.. " --query value -o tsv"
-
-				local decrypted, err = run_az_command(cmd)
-				if decrypted then
-					setting.value = vim.trim(decrypted)
-				else
-					vim.notify(
-						"Failed to decrypt '" .. setting.name .. "': " .. err,
-						vim.log.levels.WARN
-					)
-				end
 			end
 		end
 	end
@@ -76,9 +86,15 @@ end
 local function write_settings(data, output_file)
 	local json_str = vim.json.encode(data)
 
-	local file = io.open(output_file, "w")
+	local output_dir = vim.fn.fnamemodify(output_file, ":h")
+	vim.fn.mkdir(output_dir, "p")
+
+	local file, err = io.open(output_file, "w")
 	if not file then
-		vim.notify("Failed to write to " .. output_file, vim.log.levels.ERROR)
+		vim.notify(
+			"Failed to write to " .. output_file .. (err and (": " .. err) or ""),
+			vim.log.levels.ERROR
+		)
 		return false
 	end
 
@@ -120,9 +136,13 @@ function M.fetch_app_settings(config)
 	end
 
 	local settings = vim.fn.json_decode(result)
-	if not settings or #settings == 0 then
-		vim.notify("No settings found for " .. app_name .. ".", vim.log.levels.WARN)
+	if not settings then
+		vim.notify("Failed to decode settings for " .. app_name .. ".", vim.log.levels.ERROR)
 		return
+	end
+
+	if #settings == 0 then
+		vim.notify("No settings found for " .. app_name .. ". Writing empty local.settings.json.", vim.log.levels.WARN)
 	end
 
 	if config.decrypt then
@@ -131,7 +151,8 @@ function M.fetch_app_settings(config)
 
 	local local_settings = build_local_settings(settings)
 
-	local output_file = (config.output_path or vim.fn.getcwd()) .. "/local.settings.json"
+	local output_dir = vim.fn.expand(config.output_path or vim.fn.getcwd())
+	local output_file = output_dir .. "/local.settings.json"
 
 	if not write_settings(local_settings, output_file) then
 		return

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -22,20 +22,27 @@ end
 local function decrypt_settings(settings, vault_name)
 	for _, setting in ipairs(settings) do
 		if setting.value:match("^ENC%(") then
-			local cmd = "az keyvault secret show --name "
-				.. vim.fn.shellescape(setting.name)
-				.. " --vault-name "
-				.. vim.fn.shellescape(vault_name)
-				.. " --query value -o tsv"
-
-			local decrypted, err = run_az_command(cmd)
-			if decrypted then
-				setting.value = vim.trim(decrypted)
-			else
+			if not vault_name then
 				vim.notify(
-					"Failed to decrypt '" .. setting.name .. "': " .. err,
+					"Skipping decryption of '" .. setting.name .. "': key_vault_name is not configured.",
 					vim.log.levels.WARN
 				)
+			else
+				local cmd = "az keyvault secret show --name "
+					.. vim.fn.shellescape(setting.name)
+					.. " --vault-name "
+					.. vim.fn.shellescape(vault_name)
+					.. " --query value -o tsv"
+
+				local decrypted, err = run_az_command(cmd)
+				if decrypted then
+					setting.value = vim.trim(decrypted)
+				else
+					vim.notify(
+						"Failed to decrypt '" .. setting.name .. "': " .. err,
+						vim.log.levels.WARN
+					)
+				end
 			end
 		end
 	end
@@ -107,13 +114,6 @@ function M.fetch_app_settings(config)
 	end
 
 	if config.decrypt then
-		if not config.key_vault_name then
-			vim.notify(
-				"Decryption enabled but 'key_vault_name' is not set in config.",
-				vim.log.levels.ERROR
-			)
-			return
-		end
 		decrypt_settings(settings, config.key_vault_name)
 	end
 

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -1,13 +1,23 @@
 local M = {}
 
 -- Run an Azure CLI command and return the output, or nil on error.
--- stderr is redirected to stdout so error messages are always captured.
+-- Uses vim.system() (Neovim 0.9+) to keep stdout and stderr separate.
+-- Falls back to vim.fn.system() for older Neovim versions.
 local function run_az_command(cmd)
-	local result = vim.fn.system(cmd .. " 2>&1")
-	if vim.v.shell_error ~= 0 then
-		return nil, result
+	if vim.system then
+		local proc = vim.system(vim.split(cmd, " "), { text = true }):wait()
+		if proc.code ~= 0 then
+			local err = (proc.stderr ~= "" and proc.stderr) or proc.stdout
+			return nil, err
+		end
+		return proc.stdout, nil
 	end
-	return result, nil
+
+	local output = vim.fn.system(cmd)
+	if vim.v.shell_error ~= 0 then
+		return nil, output
+	end
+	return output, nil
 end
 
 -- Prompt the user for input, returns nil if cancelled or empty

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -1,11 +1,12 @@
 local M = {}
 
 -- Run an Azure CLI command and return the output, or nil on error.
+-- Accepts an argv table so arguments are never split or shell-interpreted.
 -- Uses vim.system() (Neovim 0.9+) to keep stdout and stderr separate.
 -- Falls back to vim.fn.system() for older Neovim versions.
-local function run_az_command(cmd)
+local function run_az_command(args)
 	if vim.system then
-		local proc = vim.system(vim.split(cmd, " "), { text = true }):wait()
+		local proc = vim.system(args, { text = true }):wait()
 		if proc.code ~= 0 then
 			local err = (proc.stderr ~= "" and proc.stderr) or proc.stdout
 			return nil, err
@@ -13,7 +14,8 @@ local function run_az_command(cmd)
 		return proc.stdout, nil
 	end
 
-	local output = vim.fn.system(cmd)
+	local parts = vim.tbl_map(vim.fn.shellescape, args)
+	local output = vim.fn.system(table.concat(parts, " "))
 	if vim.v.shell_error ~= 0 then
 		return nil, output
 	end
@@ -61,13 +63,15 @@ local function decrypt_settings(settings, vault_name)
 	for _, setting in ipairs(settings) do
 		if type(setting.value) == "string" and setting.value:match("^ENC%(") then
 			local secret_name = resolve_secret_name(setting.name, setting.value)
-			local cmd = "az keyvault secret show --name "
-				.. vim.fn.shellescape(secret_name)
-				.. " --vault-name "
-				.. vim.fn.shellescape(vault_name)
-				.. " --query value -o tsv"
+			local args = {
+				"az", "keyvault", "secret", "show",
+				"--name", secret_name,
+				"--vault-name", vault_name,
+				"--query", "value",
+				"-o", "tsv",
+			}
 
-			local decrypted, err = run_az_command(cmd)
+			local decrypted, err = run_az_command(args)
 			if decrypted then
 				setting.value = vim.trim(decrypted)
 			else
@@ -131,12 +135,15 @@ function M.fetch_app_settings(config)
 
 	vim.notify("Fetching settings for " .. app_name .. "...", vim.log.levels.INFO)
 
-	local cmd = "az functionapp config appsettings list"
-		.. " --name " .. vim.fn.shellescape(app_name)
-		.. " --resource-group " .. vim.fn.shellescape(resource_group)
-		.. " --query '[].{name:name, value:value}' -o json"
+	local args = {
+		"az", "functionapp", "config", "appsettings", "list",
+		"--name", app_name,
+		"--resource-group", resource_group,
+		"--query", "[].{name:name, value:value}",
+		"-o", "json",
+	}
 
-	local result, err = run_az_command(cmd)
+	local result, err = run_az_command(args)
 	if not result then
 		vim.notify(
 			"Error fetching settings:\n" .. err .. "\nTip: make sure you are logged in with `az login`.",

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -15,7 +15,7 @@ local function run_az_command(args)
 	end
 
 	local parts = vim.tbl_map(vim.fn.shellescape, args)
-	local output = vim.fn.system(table.concat(parts, " "))
+	local output = vim.fn.system(table.concat(parts, " ") .. " 2>&1")
 	if vim.v.shell_error ~= 0 then
 		return nil, output
 	end

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -18,18 +18,30 @@ local function prompt(label)
 	return value
 end
 
+-- Resolve the Key Vault secret name from an ENC(...) value.
+-- If the content inside ENC(...) is a valid secret name, use it directly.
+-- Otherwise fall back to the app setting name.
+local function resolve_secret_name(setting_name, enc_value)
+	local inner = enc_value:match("^ENC%((.-)%)$")
+	if inner and inner:match("^[a-zA-Z0-9-]+$") then
+		return inner
+	end
+	return setting_name
+end
+
 -- Decrypt any ENC(...) values by fetching them from Key Vault
 local function decrypt_settings(settings, vault_name)
 	for _, setting in ipairs(settings) do
-		if setting.value:match("^ENC%(") then
+		if type(setting.value) == "string" and setting.value:match("^ENC%(") then
 			if not vault_name then
 				vim.notify(
 					"Skipping decryption of '" .. setting.name .. "': key_vault_name is not configured.",
 					vim.log.levels.WARN
 				)
 			else
+				local secret_name = resolve_secret_name(setting.name, setting.value)
 				local cmd = "az keyvault secret show --name "
-					.. vim.fn.shellescape(setting.name)
+					.. vim.fn.shellescape(secret_name)
 					.. " --vault-name "
 					.. vim.fn.shellescape(vault_name)
 					.. " --query value -o tsv"
@@ -60,7 +72,7 @@ local function build_local_settings(settings)
 	return output
 end
 
--- Write the settings table to a file as formatted JSON
+-- Write the settings table to a file as JSON
 local function write_settings(data, output_file)
 	local json_str = vim.json.encode(data)
 

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -1,100 +1,134 @@
 local M = {}
 
--- Function to fetch and optionally decrypt app settings
-function M.fetch_app_settings(decrypt)
-	-- Prompt the user for the Azure Function App name
-	local app_name = vim.fn.input("Enter Azure Function App name: ")
-	if app_name == "" then
-		print("App name cannot be empty!")
-		return
-	end
-
-	-- Prompt the user for the Azure Function App resource group
-	local resource_group = vim.fn.input("Enter Azure Function App resource group: ")
-	if resource_group == "" then
-		print("Resource group cannot be empty!")
-		return
-	end
-
-	-- Construct the Azure CLI command to fetch app settings
-	local cmd = "az functionapp config appsettings list --name "
-		.. app_name
-		.. " --resource-group "
-		.. resource_group
-		.. " --query '[].{name:name, value:value}' -o json"
-
-	-- Execute the command and capture the output
+-- Run an Azure CLI command and return the output, or nil on error
+local function run_az_command(cmd)
 	local result = vim.fn.system(cmd)
-
-	-- Check for errors
 	if vim.v.shell_error ~= 0 then
-		print("Error fetching app settings: " .. result)
-		return
+		return nil, result
 	end
+	return result, nil
+end
 
-	-- Parse the JSON result
-	local settings = vim.fn.json_decode(result)
-	if not settings then
-		print("Failed to parse app settings.")
-		return
+-- Prompt the user for input, returns nil if cancelled or empty
+local function prompt(label)
+	local value = vim.fn.input(label)
+	if value == "" then
+		return nil
 	end
+	return value
+end
 
-	-- Handle decryption if enabled
-	if decrypt then
-		for _, setting in ipairs(settings) do
-			if setting.value:match("^ENC%(") then
-				-- Decrypt the value using Azure CLI or custom logic
-				local decrypt_cmd = "az keyvault secret show --name "
-					.. setting.name
-					.. " --vault-name <YourKeyVaultName> --query value -o tsv"
-				local decrypted_value = vim.fn.system(decrypt_cmd)
+-- Decrypt any ENC(...) values by fetching them from Key Vault
+local function decrypt_settings(settings, vault_name)
+	for _, setting in ipairs(settings) do
+		if setting.value:match("^ENC%(") then
+			local cmd = "az keyvault secret show --name "
+				.. vim.fn.shellescape(setting.name)
+				.. " --vault-name "
+				.. vim.fn.shellescape(vault_name)
+				.. " --query value -o tsv"
 
-				-- Replace the encrypted value with the decrypted value
-				if vim.v.shell_error == 0 then
-					setting.value = decrypted_value
-				else
-					print("Error decrypting value for " .. setting.name .. ": " .. decrypted_value)
-				end
+			local decrypted, err = run_az_command(cmd)
+			if decrypted then
+				setting.value = vim.trim(decrypted)
+			else
+				vim.notify(
+					"Failed to decrypt '" .. setting.name .. "': " .. err,
+					vim.log.levels.WARN
+				)
 			end
 		end
 	end
+end
 
-	-- Convert to local.settings.json format
-	local local_settings = {
+-- Convert a flat list of {name, value} settings to local.settings.json format
+local function build_local_settings(settings)
+	local output = {
 		IsEncrypted = false,
 		Values = {},
 	}
-
-	-- Add each setting to the Values object
 	for _, setting in ipairs(settings) do
-		local_settings.Values[setting.name] = setting.value
+		output.Values[setting.name] = setting.value
 	end
+	return output
+end
 
-	-- Get the current working directory
-	local cwd = vim.fn.getcwd()
-	local output_file = cwd .. "/local.settings.json"
+-- Write the settings table to a file as formatted JSON
+local function write_settings(data, output_file)
+	local json_str = vim.json.encode(data)
 
-	-- Convert back to JSON with pretty formatting
-	local json_str = vim.fn.json_encode(local_settings)
-
-	-- Pretty print JSON (optional)
-	-- This creates better formatted JSON with indentation
-	if vim.fn.has("nvim-0.7") == 1 then
-		-- For Neovim 0.7+ use the built-in JSON formatting
-		json_str = vim.json.encode(local_settings, { indent = 2 })
-	end
-
-	-- Write to file
 	local file = io.open(output_file, "w")
-	if file then
-		file:write(json_str)
-		file:close()
-		print("Settings saved to " .. output_file)
+	if not file then
+		vim.notify("Failed to write to " .. output_file, vim.log.levels.ERROR)
+		return false
+	end
 
-		-- Optionally open the file in a new buffer
-		vim.cmd("edit " .. output_file)
-	else
-		print("Failed to write settings to file")
+	file:write(json_str)
+	file:close()
+	return true
+end
+
+-- Main entry point: fetch app settings and save to local.settings.json
+function M.fetch_app_settings(config)
+	config = config or {}
+
+	local app_name = prompt("Azure Function App name: ")
+	if not app_name then
+		vim.notify("Cancelled: app name is required.", vim.log.levels.WARN)
+		return
+	end
+
+	local resource_group = prompt("Azure Resource Group: ")
+	if not resource_group then
+		vim.notify("Cancelled: resource group is required.", vim.log.levels.WARN)
+		return
+	end
+
+	vim.notify("Fetching settings for " .. app_name .. "...", vim.log.levels.INFO)
+
+	local cmd = "az functionapp config appsettings list"
+		.. " --name " .. vim.fn.shellescape(app_name)
+		.. " --resource-group " .. vim.fn.shellescape(resource_group)
+		.. " --query '[].{name:name, value:value}' -o json"
+
+	local result, err = run_az_command(cmd)
+	if not result then
+		vim.notify(
+			"Error fetching settings:\n" .. err .. "\nTip: make sure you are logged in with `az login`.",
+			vim.log.levels.ERROR
+		)
+		return
+	end
+
+	local settings = vim.fn.json_decode(result)
+	if not settings or #settings == 0 then
+		vim.notify("No settings found for " .. app_name .. ".", vim.log.levels.WARN)
+		return
+	end
+
+	if config.decrypt then
+		if not config.key_vault_name then
+			vim.notify(
+				"Decryption enabled but 'key_vault_name' is not set in config.",
+				vim.log.levels.ERROR
+			)
+			return
+		end
+		decrypt_settings(settings, config.key_vault_name)
+	end
+
+	local local_settings = build_local_settings(settings)
+
+	local output_file = (config.output_path or vim.fn.getcwd()) .. "/local.settings.json"
+
+	if not write_settings(local_settings, output_file) then
+		return
+	end
+
+	vim.notify("Settings saved to " .. output_file, vim.log.levels.INFO)
+
+	if config.open_file ~= false then
+		vim.cmd("edit " .. vim.fn.fnameescape(output_file))
 	end
 end
 

--- a/lua/azure/init.lua
+++ b/lua/azure/init.lua
@@ -29,8 +29,21 @@ function M.setup(opts)
 		open_file = opts.open_file ~= false, -- default true
 	}
 
-	local keymaps = opts.keymaps or {}
-	local fetch_key = keymaps.fetch_app_settings or "<leader>af"
+	local keymaps = opts.keymaps
+	if keymaps ~= nil and type(keymaps) ~= "table" then
+		vim.notify("azure.nvim: keymaps must be a table", vim.log.levels.ERROR)
+		return
+	end
+	keymaps = keymaps or {}
+
+	local fetch_key = keymaps.fetch_app_settings
+	if fetch_key ~= nil and type(fetch_key) ~= "string" then
+		vim.notify("azure.nvim: keymaps.fetch_app_settings must be a string", vim.log.levels.ERROR)
+		return
+	end
+	if not fetch_key or fetch_key == "" then
+		fetch_key = "<leader>af"
+	end
 
 	vim.keymap.set("n", fetch_key, function()
 		fetch.fetch_app_settings(config)

--- a/lua/azure/init.lua
+++ b/lua/azure/init.lua
@@ -8,10 +8,16 @@ local config = {}
 function M.setup(opts)
 	opts = opts or {}
 
+	local key_vault_name = opts.key_vault_name
+	if key_vault_name == "" then key_vault_name = nil end
+
+	local output_path = opts.output_path
+	if output_path == "" then output_path = nil end
+
 	config = {
 		decrypt = opts.decrypt or false,
-		key_vault_name = opts.key_vault_name or nil,
-		output_path = opts.output_path or nil,
+		key_vault_name = key_vault_name,
+		output_path = output_path,
 		open_file = opts.open_file ~= false, -- default true
 	}
 

--- a/lua/azure/init.lua
+++ b/lua/azure/init.lua
@@ -1,31 +1,30 @@
 local M = {}
 
--- Import the fetch module
 local fetch = require("azure.fetch")
 
--- Setup function for the plugin
+-- Holds the resolved config after setup() is called
+local config = {}
+
 function M.setup(opts)
 	opts = opts or {}
-	local decrypt = opts.decrypt or false
+
+	config = {
+		decrypt = opts.decrypt or false,
+		key_vault_name = opts.key_vault_name or nil,
+		output_path = opts.output_path or nil,
+		open_file = opts.open_file ~= false, -- default true
+	}
+
 	local keymaps = opts.keymaps or {}
+	local fetch_key = keymaps.fetch_app_settings or "<leader>af"
 
-	-- Default keybinding for fetching app settings
-	keymaps.fetch_app_settings = keymaps.fetch_app_settings or "<leader>af"
+	vim.keymap.set("n", fetch_key, function()
+		fetch.fetch_app_settings(config)
+	end, { noremap = true, silent = true, desc = "Azure: fetch Function App settings" })
 
-	-- Set up the keybinding for fetching app settings
-	if keymaps.fetch_app_settings then
-		vim.api.nvim_set_keymap(
-			"n",
-			keymaps.fetch_app_settings,
-			":lua require('azure.fetch').fetch_app_settings(" .. tostring(decrypt) .. ")<CR>",
-			{ noremap = true, silent = true }
-		)
-	end
-
-	-- Register the command for fetching app settings
 	vim.api.nvim_create_user_command("AzFetchAppSettings", function()
-		fetch.fetch_app_settings(decrypt)
-	end, {})
+		fetch.fetch_app_settings(config)
+	end, { desc = "Fetch Azure Function App settings" })
 end
 
 return M

--- a/lua/azure/init.lua
+++ b/lua/azure/init.lua
@@ -9,9 +9,17 @@ function M.setup(opts)
 	opts = opts or {}
 
 	local key_vault_name = opts.key_vault_name
+	if key_vault_name ~= nil and type(key_vault_name) ~= "string" then
+		vim.notify("azure.nvim: key_vault_name must be a string", vim.log.levels.ERROR)
+		return
+	end
 	if key_vault_name == "" then key_vault_name = nil end
 
 	local output_path = opts.output_path
+	if output_path ~= nil and type(output_path) ~= "string" then
+		vim.notify("azure.nvim: output_path must be a string", vim.log.levels.ERROR)
+		return
+	end
 	if output_path == "" then output_path = nil end
 
 	config = {

--- a/lua/azure/init.lua
+++ b/lua/azure/init.lua
@@ -7,6 +7,10 @@ local config = {}
 
 function M.setup(opts)
 	opts = opts or {}
+	if type(opts) ~= "table" then
+		vim.notify("azure.nvim: setup() expects a table", vim.log.levels.ERROR)
+		return
+	end
 
 	local key_vault_name = opts.key_vault_name
 	if key_vault_name ~= nil and type(key_vault_name) ~= "string" then
@@ -61,7 +65,7 @@ function M.setup(opts)
 
 	vim.api.nvim_create_user_command("AzFetchAppSettings", function()
 		fetch.fetch_app_settings(config)
-	end, { desc = "Fetch Azure Function App settings" })
+	end, { force = true, desc = "Fetch Azure Function App settings" })
 end
 
 return M

--- a/lua/azure/init.lua
+++ b/lua/azure/init.lua
@@ -22,6 +22,16 @@ function M.setup(opts)
 	end
 	if output_path == "" then output_path = nil end
 
+	if opts.decrypt ~= nil and type(opts.decrypt) ~= "boolean" then
+		vim.notify("azure.nvim: decrypt must be a boolean", vim.log.levels.ERROR)
+		return
+	end
+
+	if opts.open_file ~= nil and type(opts.open_file) ~= "boolean" then
+		vim.notify("azure.nvim: open_file must be a boolean", vim.log.levels.ERROR)
+		return
+	end
+
 	config = {
 		decrypt = opts.decrypt or false,
 		key_vault_name = key_vault_name,


### PR DESCRIPTION
## Summary

- Refactored `fetch.lua` into focused helper functions (`run_az_command`, `prompt`, `decrypt_settings`, `build_local_settings`, `write_settings`)
- Fixed shell injection vulnerability by applying `vim.fn.shellescape()` to all user inputs
- Fixed path injection in `vim.cmd("edit ...")` by using `vim.fn.fnameescape()`
- Replaced all `print()` calls with `vim.notify()` using appropriate log levels
- Replaced `vim.api.nvim_set_keymap()` with `vim.keymap.set()` and added `desc`
- Config is now passed as a table instead of loose booleans

## New config options

- `key_vault_name` — optional; used for Key Vault lookups when `decrypt = true` and settings contain `ENC(...)` values. Decryption is best-effort: if not configured, a single aggregated warning is shown and encrypted values are left as-is.
- `output_path` — custom output directory for `local.settings.json`
- `open_file` — control whether the file opens after saving (default: `true`)

## Other improvements

- `run_az_command` uses `vim.system()` (Neovim 0.9+) to keep stdout/stderr separate; falls back to `vim.fn.system()` for older versions
- `ENC(...)` secret name resolution: uses the content inside `ENC(...)` if it is a valid Key Vault secret name, otherwise falls back to the app setting name
- Output directory is created automatically with `vim.fn.mkdir(..., "p")`
- `output_path` supports `~/...` paths via `vim.fn.expand()`
- Type validation for all config options in `setup()`
- Empty settings list writes an empty `local.settings.json` instead of aborting