### PR TITLE
UX improvements: vim.ui.input and overwrite confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-03-10
+
+### Changed
+
+- Replaced `vim.fn.input()` with `vim.ui.input()` for user prompts — integrates automatically with UI plugins like `dressing.nvim` and `telescope-ui-select`
+- Extracted fetch logic into a `do_fetch()` helper to keep callback nesting clean
+
+### Added
+
+- Confirmation prompt when `local.settings.json` already exists, using `vim.ui.select()` — prevents accidental overwrites
+
 ## [0.2.0] - 2026-03-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Before using this plugin, make sure you have the following installed and configu
 require("lazy").setup({
     {
         "edwinboon/azure.nvim",
-        version = "v0.2.0",
+        version = "v0.3.0",
         config = function()
             require("azure").setup({
                 keymaps = {
@@ -52,7 +52,7 @@ require("lazy").setup({
 ```lua
 use {
     "edwinboon/azure.nvim",
-    tag = "v0.2.0",
+    tag = "v0.3.0",
     config = function()
         require("azure").setup({
             keymaps = {

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -179,14 +179,22 @@ function M.fetch_app_settings(config)
 	config = config or {}
 
 	vim.ui.input({ prompt = "Azure Function App name: " }, function(app_name)
-		if not app_name or app_name == "" then
-			vim.notify("Cancelled: app name is required.", vim.log.levels.WARN)
+		if app_name == nil then
+			vim.notify("Cancelled.", vim.log.levels.WARN)
+			return
+		end
+		if app_name == "" then
+			vim.notify("App name is required.", vim.log.levels.WARN)
 			return
 		end
 
 		vim.ui.input({ prompt = "Azure Resource Group: " }, function(resource_group)
-			if not resource_group or resource_group == "" then
-				vim.notify("Cancelled: resource group is required.", vim.log.levels.WARN)
+			if resource_group == nil then
+				vim.notify("Cancelled.", vim.log.levels.WARN)
+				return
+			end
+			if resource_group == "" then
+				vim.notify("Resource group is required.", vim.log.levels.WARN)
 				return
 			end
 

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -158,7 +158,8 @@ local function do_fetch(config, app_name, resource_group)
 		end
 	end
 
-	if vim.uv.fs_stat(output_file) then
+	local uv = vim.uv or vim.loop
+	if uv.fs_stat(output_file) then
 		vim.ui.select({ "Yes", "No" }, {
 			prompt = output_file .. " already exists. Overwrite?",
 		}, function(choice)

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -158,7 +158,7 @@ local function do_fetch(config, app_name, resource_group)
 		end
 	end
 
-	if vim.fn.filereadable(output_file) == 1 then
+	if vim.uv.fs_stat(output_file) then
 		vim.ui.select({ "Yes", "No" }, {
 			prompt = output_file .. " already exists. Overwrite?",
 		}, function(choice)

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -22,15 +22,6 @@ local function run_az_command(args)
 	return output, nil
 end
 
--- Prompt the user for input, returns nil if cancelled or empty
-local function prompt(label)
-	local value = vim.fn.input(label)
-	if value == "" then
-		return nil
-	end
-	return value
-end
-
 -- Resolve the Key Vault secret name from an ENC(...) value.
 -- If the content inside ENC(...) is a valid secret name, use it directly.
 -- Otherwise fall back to the app setting name.
@@ -117,22 +108,8 @@ local function write_settings(data, output_file)
 	return true
 end
 
--- Main entry point: fetch app settings and save to local.settings.json
-function M.fetch_app_settings(config)
-	config = config or {}
-
-	local app_name = prompt("Azure Function App name: ")
-	if not app_name then
-		vim.notify("Cancelled: app name is required.", vim.log.levels.WARN)
-		return
-	end
-
-	local resource_group = prompt("Azure Resource Group: ")
-	if not resource_group then
-		vim.notify("Cancelled: resource group is required.", vim.log.levels.WARN)
-		return
-	end
-
+-- Perform the actual fetch after inputs have been collected
+local function do_fetch(config, app_name, resource_group)
 	vim.notify("Fetching settings for " .. app_name .. "...", vim.log.levels.INFO)
 
 	local args = {
@@ -171,15 +148,50 @@ function M.fetch_app_settings(config)
 	local output_dir = vim.fn.expand(config.output_path or vim.fn.getcwd())
 	local output_file = output_dir .. "/local.settings.json"
 
-	if not write_settings(local_settings, output_file) then
-		return
+	local function save_and_open()
+		if not write_settings(local_settings, output_file) then
+			return
+		end
+		vim.notify("Settings saved to " .. output_file, vim.log.levels.INFO)
+		if config.open_file ~= false then
+			vim.cmd("edit " .. vim.fn.fnameescape(output_file))
+		end
 	end
 
-	vim.notify("Settings saved to " .. output_file, vim.log.levels.INFO)
-
-	if config.open_file ~= false then
-		vim.cmd("edit " .. vim.fn.fnameescape(output_file))
+	if vim.fn.filereadable(output_file) == 1 then
+		vim.ui.select({ "Yes", "No" }, {
+			prompt = output_file .. " already exists. Overwrite?",
+		}, function(choice)
+			if choice == "Yes" then
+				save_and_open()
+			else
+				vim.notify("Cancelled: file not overwritten.", vim.log.levels.WARN)
+			end
+		end)
+	else
+		save_and_open()
 	end
+end
+
+-- Main entry point: prompt for inputs then fetch app settings
+function M.fetch_app_settings(config)
+	config = config or {}
+
+	vim.ui.input({ prompt = "Azure Function App name: " }, function(app_name)
+		if not app_name or app_name == "" then
+			vim.notify("Cancelled: app name is required.", vim.log.levels.WARN)
+			return
+		end
+
+		vim.ui.input({ prompt = "Azure Resource Group: " }, function(resource_group)
+			if not resource_group or resource_group == "" then
+				vim.notify("Cancelled: resource group is required.", vim.log.levels.WARN)
+				return
+			end
+
+			do_fetch(config, app_name, resource_group)
+		end)
+	end)
 end
 
 return M


### PR DESCRIPTION
## Summary

- Replaced `vim.fn.input()` with `vim.ui.input()` for user prompts — integrates automatically with UI plugins like `dressing.nvim` and `telescope-ui-select`
- Added confirmation prompt when `local.settings.json` already exists — prevents accidental overwrites
- Extracted `do_fetch()` helper to keep callback nesting clean

## Test plan

- [ ] Run `:AzFetchAppSettings` and verify prompts appear correctly
- [ ] Verify overwrite confirmation appears when `local.settings.json` already exists
- [ ] Verify "No" cancels without writing
- [ ] Verify prompts use custom UI when `dressing.nvim` is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)