### PR TITLE
Add resource group and function app dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-10
+
+### Added
+
+- Resource group dropdown via `vim.ui.select` — no more manual typing
+- Function App dropdown via `vim.ui.select` — list is filtered by the selected resource group
+- New `lua/azure/az.lua` module with shared `run_az_command()` — reusable across all features
+- New `lua/azure/select.lua` module with `resource_group()` and `function_app()` pickers
+
+### Changed
+
+- `fetch_app_settings` now uses dropdowns instead of free-text input for both resource group and function app name
+
 ## [0.3.0] - 2026-03-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Before using this plugin, make sure you have the following installed and configu
 require("lazy").setup({
     {
         "edwinboon/azure.nvim",
-        version = "v0.3.0",
+        version = "v0.4.0",
         config = function()
             require("azure").setup({
                 keymaps = {
@@ -52,7 +52,7 @@ require("lazy").setup({
 ```lua
 use {
     "edwinboon/azure.nvim",
-    tag = "v0.3.0",
+    tag = "v0.4.0",
     config = function()
         require("azure").setup({
             keymaps = {
@@ -70,7 +70,9 @@ use {
 1. **Keybinding**: Press the configured keybinding (default: `<leader>af`) in normal mode.
 2. **Command**: Run `:AzFetchAppSettings`.
 
-You will be prompted for the Function App name and Resource Group. The settings will be fetched and saved as `local.settings.json` in the current working directory (or `output_path` if configured).
+A dropdown will appear to select your Resource Group, followed by a dropdown for the Function App within that group. The settings will be fetched and saved as `local.settings.json` in the current working directory (or `output_path` if configured).
+
+> **Tip:** The dropdowns integrate automatically with UI plugins like `dressing.nvim` or `telescope-ui-select` for a richer experience.
 
 ---
 

--- a/lua/azure/az.lua
+++ b/lua/azure/az.lua
@@ -1,0 +1,25 @@
+local M = {}
+
+-- Run an Azure CLI command and return the output, or nil on error.
+-- Accepts an argv table so arguments are never split or shell-interpreted.
+-- Uses vim.system() (Neovim 0.9+) to keep stdout and stderr separate.
+-- Falls back to vim.fn.system() for older Neovim versions.
+function M.run_az_command(args)
+	if vim.system then
+		local proc = vim.system(args, { text = true }):wait()
+		if proc.code ~= 0 then
+			local err = (proc.stderr ~= "" and proc.stderr) or proc.stdout
+			return nil, err
+		end
+		return proc.stdout, nil
+	end
+
+	local parts = vim.tbl_map(vim.fn.shellescape, args)
+	local output = vim.fn.system(table.concat(parts, " ") .. " 2>&1")
+	if vim.v.shell_error ~= 0 then
+		return nil, output
+	end
+	return output, nil
+end
+
+return M

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -1,26 +1,7 @@
 local M = {}
 
--- Run an Azure CLI command and return the output, or nil on error.
--- Accepts an argv table so arguments are never split or shell-interpreted.
--- Uses vim.system() (Neovim 0.9+) to keep stdout and stderr separate.
--- Falls back to vim.fn.system() for older Neovim versions.
-local function run_az_command(args)
-	if vim.system then
-		local proc = vim.system(args, { text = true }):wait()
-		if proc.code ~= 0 then
-			local err = (proc.stderr ~= "" and proc.stderr) or proc.stdout
-			return nil, err
-		end
-		return proc.stdout, nil
-	end
-
-	local parts = vim.tbl_map(vim.fn.shellescape, args)
-	local output = vim.fn.system(table.concat(parts, " ") .. " 2>&1")
-	if vim.v.shell_error ~= 0 then
-		return nil, output
-	end
-	return output, nil
-end
+local az = require("azure.az")
+local select = require("azure.select")
 
 -- Resolve the Key Vault secret name from an ENC(...) value.
 -- If the content inside ENC(...) is a valid secret name, use it directly.
@@ -62,7 +43,7 @@ local function decrypt_settings(settings, vault_name)
 				"-o", "tsv",
 			}
 
-			local decrypted, err = run_az_command(args)
+			local decrypted, err = az.run_az_command(args)
 			if decrypted then
 				setting.value = vim.trim(decrypted)
 			else
@@ -120,7 +101,7 @@ local function do_fetch(config, app_name, resource_group)
 		"-o", "json",
 	}
 
-	local result, err = run_az_command(args)
+	local result, err = az.run_az_command(args)
 	if not result then
 		vim.notify(
 			"Error fetching settings:\n" .. err .. "\nTip: make sure you are logged in with `az login`.",
@@ -174,30 +155,12 @@ local function do_fetch(config, app_name, resource_group)
 	end
 end
 
--- Main entry point: prompt for inputs then fetch app settings
+-- Main entry point: select resource group and function app, then fetch settings
 function M.fetch_app_settings(config)
 	config = config or {}
 
-	vim.ui.input({ prompt = "Azure Function App name: " }, function(app_name)
-		if app_name == nil then
-			vim.notify("Cancelled.", vim.log.levels.WARN)
-			return
-		end
-		if app_name == "" then
-			vim.notify("App name is required.", vim.log.levels.WARN)
-			return
-		end
-
-		vim.ui.input({ prompt = "Azure Resource Group: " }, function(resource_group)
-			if resource_group == nil then
-				vim.notify("Cancelled.", vim.log.levels.WARN)
-				return
-			end
-			if resource_group == "" then
-				vim.notify("Resource group is required.", vim.log.levels.WARN)
-				return
-			end
-
+	select.resource_group(function(resource_group)
+		select.function_app(resource_group, function(app_name)
 			do_fetch(config, app_name, resource_group)
 		end)
 	end)

--- a/lua/azure/select.lua
+++ b/lua/azure/select.lua
@@ -1,0 +1,70 @@
+local M = {}
+
+local run_az_command = require("azure.az").run_az_command
+
+-- Show a vim.ui.select picker for Azure resource groups.
+-- Calls callback(resource_group) on selection, or callback(nil) on cancel.
+function M.resource_group(callback)
+	vim.notify("Loading resource groups...", vim.log.levels.INFO)
+
+	local args = {
+		"az", "group", "list",
+		"--query", "[].name",
+		"-o", "json",
+	}
+
+	local result, err = run_az_command(args)
+	if not result then
+		vim.notify("Failed to load resource groups:\n" .. err, vim.log.levels.ERROR)
+		return
+	end
+
+	local groups = vim.fn.json_decode(result)
+	if not groups or #groups == 0 then
+		vim.notify("No resource groups found.", vim.log.levels.WARN)
+		return
+	end
+
+	vim.ui.select(groups, { prompt = "Select resource group:" }, function(choice)
+		if not choice then
+			vim.notify("Cancelled.", vim.log.levels.WARN)
+			return
+		end
+		callback(choice)
+	end)
+end
+
+-- Show a vim.ui.select picker for Function Apps in the given resource group.
+-- Calls callback(app_name) on selection, or callback(nil) on cancel.
+function M.function_app(resource_group, callback)
+	vim.notify("Loading function apps...", vim.log.levels.INFO)
+
+	local args = {
+		"az", "functionapp", "list",
+		"--resource-group", resource_group,
+		"--query", "[].name",
+		"-o", "json",
+	}
+
+	local result, err = run_az_command(args)
+	if not result then
+		vim.notify("Failed to load function apps:\n" .. err, vim.log.levels.ERROR)
+		return
+	end
+
+	local apps = vim.fn.json_decode(result)
+	if not apps or #apps == 0 then
+		vim.notify("No function apps found in " .. resource_group .. ".", vim.log.levels.WARN)
+		return
+	end
+
+	vim.ui.select(apps, { prompt = "Select function app:" }, function(choice)
+		if not choice then
+			vim.notify("Cancelled.", vim.log.levels.WARN)
+			return
+		end
+		callback(choice)
+	end)
+end
+
+return M

--- a/lua/azure/select.lua
+++ b/lua/azure/select.lua
@@ -3,7 +3,7 @@ local M = {}
 local run_az_command = require("azure.az").run_az_command
 
 -- Show a vim.ui.select picker for Azure resource groups.
--- Calls callback(resource_group) on selection, or callback(nil) on cancel.
+-- Calls callback(resource_group) on selection. Does not call callback on cancel or error.
 function M.resource_group(callback)
 	vim.notify("Loading resource groups...", vim.log.levels.INFO)
 
@@ -35,7 +35,7 @@ function M.resource_group(callback)
 end
 
 -- Show a vim.ui.select picker for Function Apps in the given resource group.
--- Calls callback(app_name) on selection, or callback(nil) on cancel.
+-- Calls callback(app_name) on selection. Does not call callback on cancel or error.
 function M.function_app(resource_group, callback)
 	vim.notify("Loading function apps...", vim.log.levels.INFO)
 


### PR DESCRIPTION
## Summary

- Resource group and function app selection now use `vim.ui.select` dropdowns instead of free-text input
- Resource groups are fetched from Azure via `az group list`
- Function apps are filtered by the selected resource group via `az functionapp list`
- Integrates automatically with UI plugins like `dressing.nvim` and `telescope-ui-select`

## New modules

- `lua/azure/az.lua` — shared `run_az_command()` reusable across all features
- `lua/azure/select.lua` — `resource_group()` and `function_app()` pickers

## Test plan

- [ ] Run `:AzFetchAppSettings` and verify resource group dropdown appears
- [ ] Verify function app dropdown is filtered by the selected resource group
- [ ] Verify cancelling either dropdown shows "Cancelled." and stops the flow
- [ ] Verify the full fetch flow completes correctly after both selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)