### PR TITLE
Add diff view and push functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-03-10
+
+### Added
+
+- Push functionality: push new and changed settings from `local.settings.json` to Azure via `AzPushAppSettings` / `<leader>azp`
+- Diff view: shows a colour-coded split before fetch and push operations with added, changed, unchanged and Azure-only settings
+- New `lua/azure/diff.lua` module with `compute()` and `show()` helpers
+- New `lua/azure/push.lua` module with full push flow
+- New default keybindings: `<leader>azf` (fetch) and `<leader>azp` (push)
+- New user command: `:AzPushAppSettings`
+
+### Changed
+
+- Fetch now shows a diff against the existing `local.settings.json` before overwriting, instead of a plain overwrite confirmation
+- Default fetch keybinding changed from `<leader>af` to `<leader>azf`
+
 ## [0.4.0] - 2026-03-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-03-11
+
+### Added
+
+- `swap` option in `diff.show()` to reverse before/after display and highlights for fetch-style diffs
+
+### Fixed
+
+- Fetch diff now correctly shows existing value as "before" and new Azure value as "after" using `swap = true`
+- Per-entry diff prefixes (`+`/`-`) are now swapped when `swap = true` to match section semantics
+- `existing_data.Values` is now validated to be a table (not just truthy) before use to prevent `pairs()` errors on malformed JSON
+
 ## [0.5.0] - 2026-03-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,27 +1,24 @@
 # azure.nvim
 
-A Neovim plugin to fetch and optionally decrypt Azure Function App settings directly from your editor.
+A Neovim plugin to manage Azure Function App settings directly from your editor — fetch, diff, and push without leaving Neovim.
 
 ## Features
 
 - Fetch settings from an Azure Function App and save them as `local.settings.json`.
+- Push new and changed settings from `local.settings.json` back to Azure.
+- Diff view before fetch and push — see exactly what will change.
+- Resource group and Function App selection via dropdown (integrates with `dressing.nvim`, `telescope-ui-select`).
 - Optionally decrypt `ENC(...)` values using Azure Key Vault.
-- Dynamic resource group handling for each fetch operation.
-- Configurable keybindings and commands.
-- Configurable output path and file-open behavior.
+- Configurable keybindings, output path, and file-open behavior.
 
 ---
 
 ## Prerequisites
 
-Before using this plugin, make sure you have the following installed and configured:
-
-1. **[Azure CLI](https://learn.microsoft.com/en-us/cli/azure/):**
-   - Required for fetching and decrypting Azure Function App settings.
-   - Ensure you are logged in:
-     ```bash
-     az login
-     ```
+1. **[Azure CLI](https://learn.microsoft.com/en-us/cli/azure/)** — ensure you are logged in:
+   ```bash
+   az login
+   ```
 
 2. **Neovim 0.7+**
 
@@ -35,13 +32,9 @@ Before using this plugin, make sure you have the following installed and configu
 require("lazy").setup({
     {
         "edwinboon/azure.nvim",
-        version = "v0.4.0",
+        version = "v0.5.0",
         config = function()
-            require("azure").setup({
-                keymaps = {
-                    fetch_app_settings = "<leader>af",
-                },
-            })
+            require("azure").setup()
         end,
     },
 })
@@ -52,13 +45,9 @@ require("lazy").setup({
 ```lua
 use {
     "edwinboon/azure.nvim",
-    tag = "v0.4.0",
+    tag = "v0.5.0",
     config = function()
-        require("azure").setup({
-            keymaps = {
-                fetch_app_settings = "<leader>af",
-            },
-        })
+        require("azure").setup()
     end,
 }
 ```
@@ -67,72 +56,67 @@ use {
 
 ## Usage
 
-1. **Keybinding**: Press the configured keybinding (default: `<leader>af`) in normal mode.
-2. **Command**: Run `:AzFetchAppSettings`.
+### Fetch settings
 
-A dropdown will appear to select your Resource Group, followed by a dropdown for the Function App within that group. The settings will be fetched and saved as `local.settings.json` in the current working directory (or `output_path` if configured).
+Press `<leader>azf` or run `:AzFetchAppSettings`.
 
-> **Tip:** The dropdowns integrate automatically with UI plugins like `dressing.nvim` or `telescope-ui-select` for a richer experience.
+1. Select your Resource Group from a dropdown.
+2. Select the Function App from a dropdown (filtered by resource group).
+3. A diff view opens showing what will change compared to your current `local.settings.json`.
+4. Confirm to save — the file is written and opened in the editor.
+
+### Push settings
+
+Press `<leader>azp` or run `:AzPushAppSettings`.
+
+1. Select your Resource Group and Function App.
+2. A diff view opens showing new and changed settings that will be pushed.
+3. Confirm to push — only new and changed settings are sent to Azure. Settings that exist only in Azure are left untouched.
+
+> **Tip:** Dropdowns integrate automatically with `dressing.nvim` or `telescope-ui-select`.
 
 ---
 
 ## Configuration Options
 
-| Option           | Type    | Default | Description                                                                        |
-| ---------------- | ------- | ------- | ---------------------------------------------------------------------------------- |
-| `decrypt`        | boolean | `false` | Attempt to decrypt `ENC(...)` values after fetching.                               |
-| `key_vault_name` | string  | `nil`   | Azure Key Vault name used for decryption. Required when `decrypt = true` and settings contain `ENC(...)` values. |
-| `output_path`    | string  | `nil`   | Directory to write `local.settings.json` to. Defaults to current working directory. |
-| `open_file`      | boolean | `true`  | Whether to open `local.settings.json` in the editor after saving.                  |
-| `keymaps`        | table   | `{}`    | Table of keybindings for plugin actions.                                           |
+| Option           | Type    | Default | Description                                                                                     |
+| ---------------- | ------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `decrypt`        | boolean | `false` | Attempt to decrypt `ENC(...)` values after fetching.                                            |
+| `key_vault_name` | string  | `nil`   | Azure Key Vault name. Required when `decrypt = true` and settings contain `ENC(...)` values.    |
+| `output_path`    | string  | `nil`   | Directory to write `local.settings.json` to. Defaults to current working directory.             |
+| `open_file`      | boolean | `true`  | Whether to open `local.settings.json` in the editor after saving.                               |
+| `keymaps`        | table   | `{}`    | Table of keybindings for plugin actions.                                                        |
 
 ### Keymaps Table
 
-| Key                  | Default       | Description                                        |
-| -------------------- | ------------- | -------------------------------------------------- |
-| `fetch_app_settings` | `<leader>af`  | Fetch and optionally decrypt Function App settings. |
+| Key                  | Default        | Description                                         |
+| -------------------- | -------------- | --------------------------------------------------- |
+| `fetch_app_settings` | `<leader>azf`  | Fetch Function App settings and save locally.       |
+| `push_app_settings`  | `<leader>azp`  | Push new/changed local settings to Azure.           |
 
 ---
 
 ## Decryption
 
-When `decrypt = true`, the plugin will look for settings whose value starts with `ENC(...)` and attempt to retrieve the plaintext value from Azure Key Vault.
+When `decrypt = true`, the plugin looks for settings whose value starts with `ENC(...)` and retrieves the plaintext from Azure Key Vault.
 
-The secret name is resolved as follows:
-- If the content inside `ENC(...)` is a valid Key Vault secret name (letters, numbers, hyphens), that name is used.
-- Otherwise, the app setting name is used as the secret name.
-
-**Examples:**
+Secret name resolution:
+- If the content inside `ENC(...)` is a valid Key Vault secret name (letters, numbers, hyphens) → that name is used.
+- Otherwise → the app setting name is used as the secret name.
 
 | App setting value       | Secret name used in Key Vault |
 | ----------------------- | ----------------------------- |
 | `ENC(my-secret-name)`   | `my-secret-name`              |
 | `ENC(<encrypted-blob>)` | the app setting name          |
 
-**Example configuration with decryption:**
-
-```lua
-require("azure").setup({
-    decrypt = true,
-    key_vault_name = "my-keyvault",
-    keymaps = {
-        fetch_app_settings = "<leader>af",
-    },
-})
-```
-
 ---
 
 ## Example Configuration
 
-Minimal setup:
+Minimal setup (uses all defaults):
 
 ```lua
-require("azure").setup({
-    keymaps = {
-        fetch_app_settings = "<leader>af",
-    },
-})
+require("azure").setup()
 ```
 
 Full configuration:
@@ -144,18 +128,17 @@ require("azure").setup({
     output_path = "/path/to/project",
     open_file = true,
     keymaps = {
-        fetch_app_settings = "<leader>af",
+        fetch_app_settings = "<leader>azf",
+        push_app_settings  = "<leader>azp",
     },
 })
 ```
-
-If you prefer commands over keybindings, skip the `keymaps` option and use `:AzFetchAppSettings` instead.
 
 ---
 
 ## Troubleshooting
 
-**Error fetching settings**
+**Error fetching or pushing settings**
 - Make sure you are logged in with `az login`.
 - Verify the Function App name and Resource Group are correct.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A Neovim plugin to manage Azure Function App settings directly from your editor 
 require("lazy").setup({
     {
         "edwinboon/azure.nvim",
-        version = "v0.5.0",
+        version = "v1.0.0",
         config = function()
             require("azure").setup()
         end,
@@ -45,7 +45,7 @@ require("lazy").setup({
 ```lua
 use {
     "edwinboon/azure.nvim",
-    tag = "v0.5.0",
+    tag = "v1.0.0",
     config = function()
         require("azure").setup()
     end,

--- a/lua/azure/az.lua
+++ b/lua/azure/az.lua
@@ -22,4 +22,39 @@ function M.run_az_command(args)
 	return output, nil
 end
 
+-- Fetch app settings from Azure and return a flat key→value table, or nil on error.
+function M.fetch_app_settings(app_name, resource_group)
+	local args = {
+		"az", "functionapp", "config", "appsettings", "list",
+		"--name", app_name,
+		"--resource-group", resource_group,
+		"--query", "[].{name:name, value:value}",
+		"-o", "json",
+	}
+
+	local result, err = M.run_az_command(args)
+	if not result then
+		vim.notify(
+			"Failed to fetch Azure settings:\n" .. err .. "\nTip: make sure you are logged in with `az login`.",
+			vim.log.levels.ERROR
+		)
+		return nil
+	end
+
+	local ok, settings = pcall(vim.fn.json_decode, result)
+	if not ok or not settings then
+		vim.notify(
+			"Failed to decode Azure settings — az did not return valid JSON.\n" .. tostring(settings),
+			vim.log.levels.ERROR
+		)
+		return nil
+	end
+
+	local values = {}
+	for _, s in ipairs(settings) do
+		values[s.name] = s.value
+	end
+	return values
+end
+
 return M

--- a/lua/azure/diff.lua
+++ b/lua/azure/diff.lua
@@ -2,10 +2,10 @@ local M = {}
 
 -- Compute diff between two flat key→value tables.
 -- Returns { added, changed, unchanged, azure_only }
--- added      = in local, not in Azure (will be pushed)
+-- added      = in local_values, not in azure_values
 -- changed    = in both, different value
 -- unchanged  = in both, same value
--- azure_only = in Azure, not in local (left untouched on push)
+-- azure_only = in azure_values, not in local_values
 function M.compute(local_values, azure_values)
 	local result = {
 		added = {},
@@ -34,37 +34,51 @@ function M.compute(local_values, azure_values)
 end
 
 -- Show diff in a scratch buffer split.
+-- opts.labels overrides section headers for context-specific messaging.
 -- Returns buf, win so callers can close it programmatically.
-function M.show(diff_result, title)
+function M.show(diff_result, title, opts)
+	opts = opts or {}
+	local labels = opts.labels or {
+		added     = " + New (local only — will be pushed)",
+		changed   = " ~ Changed",
+		unchanged = " = Unchanged",
+		azure_only = " - Azure only (will not be changed)",
+	}
+
 	local lines = {}
-	local highlights = {} -- { line, group }
+	local highlights = {} -- { line_index, hl_group }
+
+	local function add(line, hl_group)
+		table.insert(lines, line)
+		if hl_group then
+			table.insert(highlights, { #lines - 1, hl_group })
+		end
+	end
 
 	local function section(label, keys, format_fn, hl_group)
 		if #keys == 0 then return end
 		table.sort(keys)
-		table.insert(lines, label)
-		table.insert(highlights, { #lines - 1, "Comment" })
+		add(label, "Comment")
 		for _, key in ipairs(keys) do
-			local line = format_fn(key)
-			table.insert(lines, line)
-			table.insert(highlights, { #lines - 1, hl_group })
+			for _, l in ipairs(vim.split(format_fn(key), "\n", { plain = true })) do
+				add(l, hl_group)
+			end
 		end
-		table.insert(lines, "")
+		add("")
 	end
 
-	table.insert(lines, " " .. (title or "Azure diff"))
-	table.insert(highlights, { 0, "Title" })
-	table.insert(lines, "")
+	add(" " .. (title or "Azure diff"), "Title")
+	add("")
 
 	section(
-		" + New (local only — will be pushed)",
+		labels.added,
 		vim.tbl_keys(diff_result.added),
 		function(k) return "   + " .. k .. " = " .. tostring(diff_result.added[k]) end,
 		"DiffAdd"
 	)
 
 	section(
-		" ~ Changed",
+		labels.changed,
 		vim.tbl_keys(diff_result.changed),
 		function(k)
 			local e = diff_result.changed[k]
@@ -73,47 +87,33 @@ function M.show(diff_result, title)
 		"DiffChange"
 	)
 
-	-- Flatten multiline entries
-	local flat_lines = {}
-	local flat_highlights = {}
-	local hl_idx = 1
-	for _, raw in ipairs(lines) do
-		for _, l in ipairs(vim.split(raw, "\n", { plain = true })) do
-			table.insert(flat_lines, l)
-			if hl_idx <= #highlights and highlights[hl_idx][1] == #flat_lines - 1 then
-				table.insert(flat_highlights, { #flat_lines - 1, highlights[hl_idx][2] })
-				hl_idx = hl_idx + 1
-			end
-		end
-	end
-
 	section(
-		" = Unchanged",
+		labels.unchanged,
 		vim.tbl_keys(diff_result.unchanged),
 		function(k) return "   = " .. k end,
 		"Comment"
 	)
 
 	section(
-		" - Azure only (will not be changed)",
+		labels.azure_only,
 		vim.tbl_keys(diff_result.azure_only),
 		function(k) return "   - " .. k end,
 		"DiffDelete"
 	)
 
 	local buf = vim.api.nvim_create_buf(false, true)
-	vim.api.nvim_buf_set_lines(buf, 0, -1, false, flat_lines)
+	vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
 	vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
 	vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
 
-	for _, hl in ipairs(flat_highlights) do
+	for _, hl in ipairs(highlights) do
 		vim.api.nvim_buf_add_highlight(buf, -1, hl[2], hl[1], 0, -1)
 	end
 
 	vim.cmd("botright split")
 	local win = vim.api.nvim_get_current_win()
 	vim.api.nvim_win_set_buf(win, buf)
-	vim.api.nvim_win_set_height(win, math.min(#flat_lines + 2, 20))
+	vim.api.nvim_win_set_height(win, math.min(#lines + 2, 20))
 
 	vim.keymap.set("n", "q", function()
 		if vim.api.nvim_win_is_valid(win) then

--- a/lua/azure/diff.lua
+++ b/lua/azure/diff.lua
@@ -78,7 +78,7 @@ function M.show(diff_result, title, opts)
 	section(
 		labels.added,
 		vim.tbl_keys(diff_result.added),
-		function(k) return "   + " .. k .. " = " .. tostring(diff_result.added[k]) end,
+		function(k) return "   " .. (swap and "-" or "+") .. " " .. k .. " = " .. tostring(diff_result.added[k]) end,
 		swap and "DiffDelete" or "DiffAdd"
 	)
 
@@ -106,7 +106,7 @@ function M.show(diff_result, title, opts)
 	section(
 		labels.azure_only,
 		vim.tbl_keys(diff_result.azure_only),
-		function(k) return "   - " .. k end,
+		function(k) return "   " .. (swap and "+" or "-") .. " " .. k end,
 		swap and "DiffAdd" or "DiffDelete"
 	)
 

--- a/lua/azure/diff.lua
+++ b/lua/azure/diff.lua
@@ -103,8 +103,8 @@ function M.show(diff_result, title, opts)
 
 	local buf = vim.api.nvim_create_buf(false, true)
 	vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-	vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
-	vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
+	vim.bo[buf].modifiable = false
+	vim.bo[buf].bufhidden = "wipe"
 
 	for _, hl in ipairs(highlights) do
 		vim.api.nvim_buf_add_highlight(buf, -1, hl[2], hl[1], 0, -1)

--- a/lua/azure/diff.lua
+++ b/lua/azure/diff.lua
@@ -48,6 +48,7 @@ function M.show(diff_result, title, opts)
 		before = "azure",
 		after  = "local",
 	}
+	local swap = opts.swap or false
 
 	local lines = {}
 	local highlights = {} -- { line_index, hl_group }
@@ -78,7 +79,7 @@ function M.show(diff_result, title, opts)
 		labels.added,
 		vim.tbl_keys(diff_result.added),
 		function(k) return "   + " .. k .. " = " .. tostring(diff_result.added[k]) end,
-		"DiffAdd"
+		swap and "DiffDelete" or "DiffAdd"
 	)
 
 	section(
@@ -86,9 +87,11 @@ function M.show(diff_result, title, opts)
 		vim.tbl_keys(diff_result.changed),
 		function(k)
 			local e = diff_result.changed[k]
+			local before_val = swap and e.local_val or e.azure_val
+			local after_val  = swap and e.azure_val or e.local_val
 			return "   ~ " .. k
-				.. "\n       " .. changed_labels.before .. ": " .. tostring(e.azure_val)
-				.. "\n       " .. changed_labels.after  .. ": " .. tostring(e.local_val)
+				.. "\n       " .. changed_labels.before .. ": " .. tostring(before_val)
+				.. "\n       " .. changed_labels.after  .. ": " .. tostring(after_val)
 		end,
 		"DiffChange"
 	)
@@ -104,7 +107,7 @@ function M.show(diff_result, title, opts)
 		labels.azure_only,
 		vim.tbl_keys(diff_result.azure_only),
 		function(k) return "   - " .. k end,
-		"DiffDelete"
+		swap and "DiffAdd" or "DiffDelete"
 	)
 
 	local buf = vim.api.nvim_create_buf(false, true)

--- a/lua/azure/diff.lua
+++ b/lua/azure/diff.lua
@@ -1,0 +1,134 @@
+local M = {}
+
+-- Compute diff between two flat key→value tables.
+-- Returns { added, changed, unchanged, azure_only }
+-- added      = in local, not in Azure (will be pushed)
+-- changed    = in both, different value
+-- unchanged  = in both, same value
+-- azure_only = in Azure, not in local (left untouched on push)
+function M.compute(local_values, azure_values)
+	local result = {
+		added = {},
+		changed = {},
+		unchanged = {},
+		azure_only = {},
+	}
+
+	for key, value in pairs(local_values) do
+		if azure_values[key] == nil then
+			result.added[key] = value
+		elseif tostring(azure_values[key]) ~= tostring(value) then
+			result.changed[key] = { local_val = value, azure_val = azure_values[key] }
+		else
+			result.unchanged[key] = value
+		end
+	end
+
+	for key, value in pairs(azure_values) do
+		if local_values[key] == nil then
+			result.azure_only[key] = value
+		end
+	end
+
+	return result
+end
+
+-- Show diff in a scratch buffer split.
+-- Returns buf, win so callers can close it programmatically.
+function M.show(diff_result, title)
+	local lines = {}
+	local highlights = {} -- { line, group }
+
+	local function section(label, keys, format_fn, hl_group)
+		if #keys == 0 then return end
+		table.sort(keys)
+		table.insert(lines, label)
+		table.insert(highlights, { #lines - 1, "Comment" })
+		for _, key in ipairs(keys) do
+			local line = format_fn(key)
+			table.insert(lines, line)
+			table.insert(highlights, { #lines - 1, hl_group })
+		end
+		table.insert(lines, "")
+	end
+
+	table.insert(lines, " " .. (title or "Azure diff"))
+	table.insert(highlights, { 0, "Title" })
+	table.insert(lines, "")
+
+	section(
+		" + New (local only — will be pushed)",
+		vim.tbl_keys(diff_result.added),
+		function(k) return "   + " .. k .. " = " .. tostring(diff_result.added[k]) end,
+		"DiffAdd"
+	)
+
+	section(
+		" ~ Changed",
+		vim.tbl_keys(diff_result.changed),
+		function(k)
+			local e = diff_result.changed[k]
+			return "   ~ " .. k .. "\n       azure: " .. tostring(e.azure_val) .. "\n       local: " .. tostring(e.local_val)
+		end,
+		"DiffChange"
+	)
+
+	-- Flatten multiline entries
+	local flat_lines = {}
+	local flat_highlights = {}
+	local hl_idx = 1
+	for _, raw in ipairs(lines) do
+		for _, l in ipairs(vim.split(raw, "\n", { plain = true })) do
+			table.insert(flat_lines, l)
+			if hl_idx <= #highlights and highlights[hl_idx][1] == #flat_lines - 1 then
+				table.insert(flat_highlights, { #flat_lines - 1, highlights[hl_idx][2] })
+				hl_idx = hl_idx + 1
+			end
+		end
+	end
+
+	section(
+		" = Unchanged",
+		vim.tbl_keys(diff_result.unchanged),
+		function(k) return "   = " .. k end,
+		"Comment"
+	)
+
+	section(
+		" - Azure only (will not be changed)",
+		vim.tbl_keys(diff_result.azure_only),
+		function(k) return "   - " .. k end,
+		"DiffDelete"
+	)
+
+	local buf = vim.api.nvim_create_buf(false, true)
+	vim.api.nvim_buf_set_lines(buf, 0, -1, false, flat_lines)
+	vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+	vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
+
+	for _, hl in ipairs(flat_highlights) do
+		vim.api.nvim_buf_add_highlight(buf, -1, hl[2], hl[1], 0, -1)
+	end
+
+	vim.cmd("botright split")
+	local win = vim.api.nvim_get_current_win()
+	vim.api.nvim_win_set_buf(win, buf)
+	vim.api.nvim_win_set_height(win, math.min(#flat_lines + 2, 20))
+
+	vim.keymap.set("n", "q", function()
+		if vim.api.nvim_win_is_valid(win) then
+			vim.api.nvim_win_close(win, true)
+		end
+	end, { buffer = buf, nowait = true })
+
+	return buf, win
+end
+
+-- Safely close the diff window (no-op if already closed)
+function M.close(win)
+	if win and vim.api.nvim_win_is_valid(win) then
+		vim.api.nvim_win_close(win, true)
+	end
+end
+
+return M

--- a/lua/azure/diff.lua
+++ b/lua/azure/diff.lua
@@ -39,10 +39,14 @@ end
 function M.show(diff_result, title, opts)
 	opts = opts or {}
 	local labels = opts.labels or {
-		added     = " + New (local only — will be pushed)",
-		changed   = " ~ Changed",
-		unchanged = " = Unchanged",
+		added      = " + New (local only — will be pushed)",
+		changed    = " ~ Changed",
+		unchanged  = " = Unchanged",
 		azure_only = " - Azure only (will not be changed)",
+	}
+	local changed_labels = opts.changed_labels or {
+		before = "azure",
+		after  = "local",
 	}
 
 	local lines = {}
@@ -82,7 +86,9 @@ function M.show(diff_result, title, opts)
 		vim.tbl_keys(diff_result.changed),
 		function(k)
 			local e = diff_result.changed[k]
-			return "   ~ " .. k .. "\n       azure: " .. tostring(e.azure_val) .. "\n       local: " .. tostring(e.local_val)
+			return "   ~ " .. k
+				.. "\n       " .. changed_labels.before .. ": " .. tostring(e.azure_val)
+				.. "\n       " .. changed_labels.after  .. ": " .. tostring(e.local_val)
 		end,
 		"DiffChange"
 	)

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -142,8 +142,8 @@ local function do_fetch(config, app_name, resource_group)
 
 	local uv = vim.uv or vim.loop
 	if uv.fs_stat(output_file) then
-		-- Load existing file and show diff before overwriting
-		local existing_values = {}
+		-- Try to load existing file for diff
+		local existing_values = nil
 		local existing_file = io.open(output_file, "r")
 		if existing_file then
 			local content = existing_file:read("*a")
@@ -151,30 +151,48 @@ local function do_fetch(config, app_name, resource_group)
 			local ok, existing_data = pcall(vim.fn.json_decode, content)
 			if ok and existing_data and existing_data.Values then
 				existing_values = existing_data.Values
+			else
+				vim.notify(
+					"Could not parse existing local.settings.json — showing overwrite confirmation instead of diff.",
+					vim.log.levels.WARN
+				)
 			end
 		end
 
-		-- Compute from Azure perspective: what will be added/changed/removed locally
-		local d = diff.compute(local_settings.Values, existing_values)
-		local _, win = diff.show(d, "Fetch diff: " .. app_name, {
-			labels = {
-				added     = " + Will be added to local file",
-				changed   = " ~ Will be updated in local file",
-				unchanged = " = Unchanged",
-				azure_only = " - Will be removed from local file",
-			},
-		})
+		if existing_values then
+			-- Show diff against existing file
+			local d = diff.compute(local_settings.Values, existing_values)
+			local _, win = diff.show(d, "Fetch diff: " .. app_name, {
+				labels = {
+					added      = " + Will be added to local file",
+					changed    = " ~ Will be updated in local file",
+					unchanged  = " = Unchanged",
+					azure_only = " - Will be removed from local file",
+				},
+			})
 
-		vim.ui.select({ "Yes", "No" }, {
-			prompt = "Apply these changes to " .. output_file .. "?",
-		}, function(choice)
-			diff.close(win)
-			if choice == "Yes" then
-				save_and_open()
-			else
-				vim.notify("Cancelled: file not updated.", vim.log.levels.WARN)
-			end
-		end)
+			vim.ui.select({ "Yes", "No" }, {
+				prompt = "Apply these changes to " .. output_file .. "?",
+			}, function(choice)
+				diff.close(win)
+				if choice == "Yes" then
+					save_and_open()
+				else
+					vim.notify("Cancelled: file not updated.", vim.log.levels.WARN)
+				end
+			end)
+		else
+			-- Fallback: simple overwrite confirmation
+			vim.ui.select({ "Yes", "No" }, {
+				prompt = output_file .. " already exists. Overwrite?",
+			}, function(choice)
+				if choice == "Yes" then
+					save_and_open()
+				else
+					vim.notify("Cancelled: file not overwritten.", vim.log.levels.WARN)
+				end
+			end)
+		end
 	else
 		save_and_open()
 	end

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local az = require("azure.az")
 local select = require("azure.select")
+local diff = require("azure.diff")
 
 -- Resolve the Key Vault secret name from an ENC(...) value.
 -- If the content inside ENC(...) is a valid secret name, use it directly.
@@ -141,13 +142,29 @@ local function do_fetch(config, app_name, resource_group)
 
 	local uv = vim.uv or vim.loop
 	if uv.fs_stat(output_file) then
+		-- Load existing file and show diff before overwriting
+		local existing_file = io.open(output_file, "r")
+		local existing_values = {}
+		if existing_file then
+			local content = existing_file:read("*a")
+			existing_file:close()
+			local existing_data = vim.fn.json_decode(content)
+			if existing_data and existing_data.Values then
+				existing_values = existing_data.Values
+			end
+		end
+
+		local d = diff.compute(existing_values, local_settings.Values)
+		local _, win = diff.show(d, "Fetch diff: " .. app_name)
+
 		vim.ui.select({ "Yes", "No" }, {
-			prompt = output_file .. " already exists. Overwrite?",
+			prompt = "Apply these changes to " .. output_file .. "?",
 		}, function(choice)
+			diff.close(win)
 			if choice == "Yes" then
 				save_and_open()
 			else
-				vim.notify("Cancelled: file not overwritten.", vim.log.levels.WARN)
+				vim.notify("Cancelled: file not updated.", vim.log.levels.WARN)
 			end
 		end)
 	else

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -94,27 +94,13 @@ end
 local function do_fetch(config, app_name, resource_group)
 	vim.notify("Fetching settings for " .. app_name .. "...", vim.log.levels.INFO)
 
-	local args = {
-		"az", "functionapp", "config", "appsettings", "list",
-		"--name", app_name,
-		"--resource-group", resource_group,
-		"--query", "[].{name:name, value:value}",
-		"-o", "json",
-	}
+	local azure_values = az.fetch_app_settings(app_name, resource_group)
+	if not azure_values then return end
 
-	local result, err = az.run_az_command(args)
-	if not result then
-		vim.notify(
-			"Error fetching settings:\n" .. err .. "\nTip: make sure you are logged in with `az login`.",
-			vim.log.levels.ERROR
-		)
-		return
-	end
-
-	local settings = vim.fn.json_decode(result)
-	if not settings then
-		vim.notify("Failed to decode settings for " .. app_name .. ".", vim.log.levels.ERROR)
-		return
+	-- Convert flat key→value table back to list format for decrypt_settings
+	local settings = {}
+	for k, v in pairs(azure_values) do
+		table.insert(settings, { name = k, value = v })
 	end
 
 	if #settings == 0 then
@@ -144,8 +130,13 @@ local function do_fetch(config, app_name, resource_group)
 	if uv.fs_stat(output_file) then
 		-- Try to load existing file for diff
 		local existing_values = nil
-		local existing_file = io.open(output_file, "r")
-		if existing_file then
+		local existing_file, open_err = io.open(output_file, "r")
+		if not existing_file then
+			vim.notify(
+				"Could not read existing local.settings.json" .. (open_err and (": " .. open_err) or "") .. " — showing overwrite confirmation instead of diff.",
+				vim.log.levels.WARN
+			)
+		else
 			local content = existing_file:read("*a")
 			existing_file:close()
 			local ok, existing_data = pcall(vim.fn.json_decode, content)
@@ -153,7 +144,7 @@ local function do_fetch(config, app_name, resource_group)
 				existing_values = existing_data.Values
 			else
 				vim.notify(
-					"Could not parse existing local.settings.json — showing overwrite confirmation instead of diff.",
+					"Could not parse existing local.settings.json" .. (not ok and (": " .. tostring(existing_data)) or "") .. " — showing overwrite confirmation instead of diff.",
 					vim.log.levels.WARN
 				)
 			end

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -140,7 +140,7 @@ local function do_fetch(config, app_name, resource_group)
 			local content = existing_file:read("*a")
 			existing_file:close()
 			local ok, existing_data = pcall(vim.fn.json_decode, content)
-			if ok and existing_data and existing_data.Values then
+			if ok and type(existing_data) == "table" and type(existing_data.Values) == "table" then
 				existing_values = existing_data.Values
 			else
 				vim.notify(

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -151,7 +151,10 @@ local function do_fetch(config, app_name, resource_group)
 		end
 
 		if existing_values then
-			-- compute(existing, azure): local_val = existing, azure_val = new from Azure
+			-- compute(existing, new_azure): local_val = existing file, azure_val = new from Azure
+			-- added      = in existing file, not in new Azure → will be removed from local
+			-- azure_only = in new Azure, not in existing file  → will be added to local
+			-- swap = true: show existing (local_val) as "before", new Azure (azure_val) as "after"
 			local d = diff.compute(existing_values, local_settings.Values)
 			local _, win = diff.show(d, "Fetch diff: " .. app_name, {
 				labels = {
@@ -164,6 +167,7 @@ local function do_fetch(config, app_name, resource_group)
 					before = "existing",
 					after  = "new from Azure",
 				},
+				swap = true,
 			})
 
 			vim.ui.select({ "Yes", "No" }, {

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -160,14 +160,14 @@ local function do_fetch(config, app_name, resource_group)
 		end
 
 		if existing_values then
-			-- Show diff against existing file
-			local d = diff.compute(local_settings.Values, existing_values)
+			-- compute(existing, azure): local_val = existing, azure_val = new from Azure
+			local d = diff.compute(existing_values, local_settings.Values)
 			local _, win = diff.show(d, "Fetch diff: " .. app_name, {
 				labels = {
-					added      = " + Will be added to local file",
+					added      = " - Will be removed from local file",
 					changed    = " ~ Will be updated in local file",
 					unchanged  = " = Unchanged",
-					azure_only = " - Will be removed from local file",
+					azure_only = " + Will be added to local file",
 				},
 			})
 

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -143,19 +143,27 @@ local function do_fetch(config, app_name, resource_group)
 	local uv = vim.uv or vim.loop
 	if uv.fs_stat(output_file) then
 		-- Load existing file and show diff before overwriting
-		local existing_file = io.open(output_file, "r")
 		local existing_values = {}
+		local existing_file = io.open(output_file, "r")
 		if existing_file then
 			local content = existing_file:read("*a")
 			existing_file:close()
-			local existing_data = vim.fn.json_decode(content)
-			if existing_data and existing_data.Values then
+			local ok, existing_data = pcall(vim.fn.json_decode, content)
+			if ok and existing_data and existing_data.Values then
 				existing_values = existing_data.Values
 			end
 		end
 
-		local d = diff.compute(existing_values, local_settings.Values)
-		local _, win = diff.show(d, "Fetch diff: " .. app_name)
+		-- Compute from Azure perspective: what will be added/changed/removed locally
+		local d = diff.compute(local_settings.Values, existing_values)
+		local _, win = diff.show(d, "Fetch diff: " .. app_name, {
+			labels = {
+				added     = " + Will be added to local file",
+				changed   = " ~ Will be updated in local file",
+				unchanged = " = Unchanged",
+				azure_only = " - Will be removed from local file",
+			},
+		})
 
 		vim.ui.select({ "Yes", "No" }, {
 			prompt = "Apply these changes to " .. output_file .. "?",

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -160,6 +160,10 @@ local function do_fetch(config, app_name, resource_group)
 					unchanged  = " = Unchanged",
 					azure_only = " + Will be added to local file",
 				},
+				changed_labels = {
+					before = "existing",
+					after  = "new from Azure",
+				},
 			})
 
 			vim.ui.select({ "Yes", "No" }, {

--- a/lua/azure/init.lua
+++ b/lua/azure/init.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local fetch = require("azure.fetch")
+local push = require("azure.push")
 
 -- Holds the resolved config after setup() is called
 local config = {}
@@ -56,16 +57,33 @@ function M.setup(opts)
 		return
 	end
 	if not fetch_key or fetch_key == "" then
-		fetch_key = "<leader>af"
+		fetch_key = "<leader>azf"
+	end
+
+	local push_key = keymaps.push_app_settings
+	if push_key ~= nil and type(push_key) ~= "string" then
+		vim.notify("azure.nvim: keymaps.push_app_settings must be a string", vim.log.levels.ERROR)
+		return
+	end
+	if not push_key or push_key == "" then
+		push_key = "<leader>azp"
 	end
 
 	vim.keymap.set("n", fetch_key, function()
 		fetch.fetch_app_settings(config)
 	end, { noremap = true, silent = true, desc = "Azure: fetch Function App settings" })
 
+	vim.keymap.set("n", push_key, function()
+		push.push_app_settings(config)
+	end, { noremap = true, silent = true, desc = "Azure: push Function App settings" })
+
 	vim.api.nvim_create_user_command("AzFetchAppSettings", function()
 		fetch.fetch_app_settings(config)
 	end, { force = true, desc = "Fetch Azure Function App settings" })
+
+	vim.api.nvim_create_user_command("AzPushAppSettings", function()
+		push.push_app_settings(config)
+	end, { force = true, desc = "Push local settings to Azure Function App" })
 end
 
 return M

--- a/lua/azure/push.lua
+++ b/lua/azure/push.lua
@@ -24,9 +24,9 @@ local function load_local_settings(config)
 	local content = file:read("*a")
 	file:close()
 
-	local data = vim.fn.json_decode(content)
-	if not data or not data.Values then
-		vim.notify("Invalid local.settings.json format.", vim.log.levels.ERROR)
+	local ok, data = pcall(vim.fn.json_decode, content)
+	if not ok or not data or not data.Values then
+		vim.notify("Failed to parse local.settings.json — invalid JSON.", vim.log.levels.ERROR)
 		return nil
 	end
 

--- a/lua/azure/push.lua
+++ b/lua/azure/push.lua
@@ -52,9 +52,9 @@ local function fetch_azure_values(app_name, resource_group)
 		return nil
 	end
 
-	local settings = vim.fn.json_decode(result)
-	if not settings then
-		vim.notify("Failed to decode Azure settings.", vim.log.levels.ERROR)
+	local ok, settings = pcall(vim.fn.json_decode, result)
+	if not ok or not settings then
+		vim.notify("Failed to decode Azure settings — az did not return valid JSON.", vim.log.levels.ERROR)
 		return nil
 	end
 

--- a/lua/azure/push.lua
+++ b/lua/azure/push.lua
@@ -1,0 +1,141 @@
+local M = {}
+
+local az = require("azure.az")
+local select = require("azure.select")
+local diff = require("azure.diff")
+
+-- Read and parse local.settings.json, returns the Values table or nil on error
+local function load_local_settings(config)
+	local output_dir = vim.fn.expand(config.output_path or vim.fn.getcwd())
+	local path = output_dir .. "/local.settings.json"
+
+	local uv = vim.uv or vim.loop
+	if not uv.fs_stat(path) then
+		vim.notify("local.settings.json not found at " .. path, vim.log.levels.ERROR)
+		return nil
+	end
+
+	local file = io.open(path, "r")
+	if not file then
+		vim.notify("Failed to read " .. path, vim.log.levels.ERROR)
+		return nil
+	end
+
+	local content = file:read("*a")
+	file:close()
+
+	local data = vim.fn.json_decode(content)
+	if not data or not data.Values then
+		vim.notify("Invalid local.settings.json format.", vim.log.levels.ERROR)
+		return nil
+	end
+
+	return data.Values
+end
+
+-- Fetch current Azure settings as a flat key→value table
+local function fetch_azure_values(app_name, resource_group)
+	local args = {
+		"az", "functionapp", "config", "appsettings", "list",
+		"--name", app_name,
+		"--resource-group", resource_group,
+		"--query", "[].{name:name, value:value}",
+		"-o", "json",
+	}
+
+	local result, err = az.run_az_command(args)
+	if not result then
+		vim.notify(
+			"Failed to fetch Azure settings:\n" .. err .. "\nTip: make sure you are logged in with `az login`.",
+			vim.log.levels.ERROR
+		)
+		return nil
+	end
+
+	local settings = vim.fn.json_decode(result)
+	if not settings then
+		vim.notify("Failed to decode Azure settings.", vim.log.levels.ERROR)
+		return nil
+	end
+
+	local values = {}
+	for _, s in ipairs(settings) do
+		values[s.name] = s.value
+	end
+	return values
+end
+
+-- Perform the actual push after inputs have been collected
+local function do_push(config, app_name, resource_group)
+	local local_values = load_local_settings(config)
+	if not local_values then return end
+
+	vim.notify("Fetching current Azure settings for " .. app_name .. "...", vim.log.levels.INFO)
+
+	local azure_values = fetch_azure_values(app_name, resource_group)
+	if not azure_values then return end
+
+	local d = diff.compute(local_values, azure_values)
+
+	local to_push = {}
+	for key, value in pairs(d.added) do
+		to_push[key] = value
+	end
+	for key, entry in pairs(d.changed) do
+		to_push[key] = entry.local_val
+	end
+
+	if vim.tbl_count(to_push) == 0 then
+		vim.notify("Nothing to push — local settings match Azure.", vim.log.levels.INFO)
+		return
+	end
+
+	local _, win = diff.show(d, "Push diff: " .. app_name)
+
+	vim.ui.select({ "Yes", "No" }, {
+		prompt = "Push " .. vim.tbl_count(to_push) .. " new/changed setting(s) to " .. app_name .. "?",
+	}, function(choice)
+		diff.close(win)
+
+		if choice ~= "Yes" then
+			vim.notify("Push cancelled.", vim.log.levels.WARN)
+			return
+		end
+
+		vim.notify("Pushing " .. vim.tbl_count(to_push) .. " setting(s) to " .. app_name .. "...", vim.log.levels.INFO)
+
+		local args = {
+			"az", "functionapp", "config", "appsettings", "set",
+			"--name", app_name,
+			"--resource-group", resource_group,
+			"--settings",
+		}
+		for key, value in pairs(to_push) do
+			table.insert(args, key .. "=" .. tostring(value))
+		end
+
+		local result, err = az.run_az_command(args)
+		if not result then
+			vim.notify("Failed to push settings:\n" .. err, vim.log.levels.ERROR)
+			return
+		end
+
+		vim.notify(
+			"Successfully pushed " .. vim.tbl_count(to_push) .. " setting(s) to " .. app_name .. ".",
+			vim.log.levels.INFO
+		)
+	end)
+end
+
+-- Main entry point: select resource group and function app, then push
+function M.push_app_settings(config)
+	config = config or {}
+
+	select.resource_group(function(resource_group)
+		select.function_app(resource_group, function(app_name)
+			do_push(config, app_name, resource_group)
+		end)
+	end)
+end
+
+return M

--- a/lua/azure/push.lua
+++ b/lua/azure/push.lua
@@ -25,8 +25,18 @@ local function load_local_settings(config)
 	file:close()
 
 	local ok, data = pcall(vim.fn.json_decode, content)
-	if not ok or not data or not data.Values then
-		vim.notify("Failed to parse local.settings.json — invalid JSON.", vim.log.levels.ERROR)
+	if not ok then
+		vim.notify(
+			"Failed to parse local.settings.json — invalid JSON:\n" .. tostring(data),
+			vim.log.levels.ERROR
+		)
+		return nil
+	end
+	if not data or not data.Values then
+		vim.notify(
+			"Failed to parse local.settings.json — missing or invalid 'Values' table.",
+			vim.log.levels.ERROR
+		)
 		return nil
 	end
 

--- a/lua/azure/push.lua
+++ b/lua/azure/push.lua
@@ -33,37 +33,6 @@ local function load_local_settings(config)
 	return data.Values
 end
 
--- Fetch current Azure settings as a flat key→value table
-local function fetch_azure_values(app_name, resource_group)
-	local args = {
-		"az", "functionapp", "config", "appsettings", "list",
-		"--name", app_name,
-		"--resource-group", resource_group,
-		"--query", "[].{name:name, value:value}",
-		"-o", "json",
-	}
-
-	local result, err = az.run_az_command(args)
-	if not result then
-		vim.notify(
-			"Failed to fetch Azure settings:\n" .. err .. "\nTip: make sure you are logged in with `az login`.",
-			vim.log.levels.ERROR
-		)
-		return nil
-	end
-
-	local ok, settings = pcall(vim.fn.json_decode, result)
-	if not ok or not settings then
-		vim.notify("Failed to decode Azure settings — az did not return valid JSON.", vim.log.levels.ERROR)
-		return nil
-	end
-
-	local values = {}
-	for _, s in ipairs(settings) do
-		values[s.name] = s.value
-	end
-	return values
-end
 
 -- Perform the actual push after inputs have been collected
 local function do_push(config, app_name, resource_group)
@@ -72,7 +41,7 @@ local function do_push(config, app_name, resource_group)
 
 	vim.notify("Fetching current Azure settings for " .. app_name .. "...", vim.log.levels.INFO)
 
-	local azure_values = fetch_azure_values(app_name, resource_group)
+	local azure_values = az.fetch_app_settings(app_name, resource_group)
 	if not azure_values then return end
 
 	local d = diff.compute(local_values, azure_values)


### PR DESCRIPTION
## Summary

- Push new and changed settings from `local.settings.json` to Azure via `AzPushAppSettings` / `<leader>azp`
- Diff view before both fetch and push — colour-coded split showing added, changed, unchanged and Azure-only settings
- Default keybindings changed to `<leader>azf` (fetch) and `<leader>azp` (push)

## New files

- `lua/azure/diff.lua` — `compute()` and `show()` helpers, reusable across fetch and push
- `lua/azure/push.lua` — full push flow with resource group/app selection and diff confirmation

## Changes

- `fetch.lua` — diff shown before overwriting instead of plain overwrite prompt
- `init.lua` — new `AzPushAppSettings` command and `push_app_settings` keymap

## Test plan

- [ ] Run `<leader>azf` and verify diff view appears when `local.settings.json` exists
- [ ] Confirm fetch applies changes, cancel leaves file untouched
- [ ] Run `<leader>azp` and verify diff view shows new/changed settings
- [ ] Confirm push only sends new/changed settings
- [ ] Verify Azure-only settings are left untouched after push
- [ ] Verify nothing is pushed when local and Azure are in sync
