### PR TITLE
Use current buffer directory for local.settings.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-03-11
+
+### Fixed
+
+- `local.settings.json` is now read from and written to the directory of the currently open buffer (`%:p:h`) instead of `getcwd()`. This means the correct app folder is used when working in a monorepo or multi-app project. Falls back to `getcwd()` if no buffer is open. `output_path` in config still takes precedence when set.
+
 ## [1.0.1] - 2026-03-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Run `:AzPushAppSettings` or use your configured keymap.
 | ---------------- | ------- | ------- | ----------------------------------------------------------------------------------------------- |
 | `decrypt`        | boolean | `false` | Attempt to decrypt `ENC(...)` values after fetching.                                            |
 | `key_vault_name` | string  | `nil`   | Azure Key Vault name. Required when `decrypt = true` and settings contain `ENC(...)` values.    |
-| `output_path`    | string  | `nil`   | Directory to write `local.settings.json` to. Defaults to current working directory.             |
+| `output_path`    | string  | `nil`   | Directory to write `local.settings.json` to. Defaults to the directory of the current buffer, falling back to `getcwd()`.             |
 | `open_file`      | boolean | `true`  | Whether to open `local.settings.json` in the editor after saving.                               |
 | `keymaps`        | table   | `{}`    | Table of keybindings for plugin actions.                                                        |
 

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -113,8 +113,12 @@ local function do_fetch(config, app_name, resource_group)
 
 	local local_settings = build_local_settings(settings)
 
+	local uv = vim.uv or vim.loop
 	local buf_dir = vim.fn.expand("%:p:h")
-	local output_dir = vim.fn.expand(config.output_path or (buf_dir ~= "" and buf_dir or vim.fn.getcwd()))
+	if buf_dir == "" or not uv.fs_stat(buf_dir) then
+		buf_dir = vim.fn.getcwd()
+	end
+	local output_dir = vim.fn.expand(config.output_path or buf_dir)
 	local output_file = output_dir .. "/local.settings.json"
 
 	local function save_and_open()

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -113,7 +113,8 @@ local function do_fetch(config, app_name, resource_group)
 
 	local local_settings = build_local_settings(settings)
 
-	local output_dir = vim.fn.expand(config.output_path or vim.fn.getcwd())
+	local buf_dir = vim.fn.expand("%:p:h")
+	local output_dir = vim.fn.expand(config.output_path or (buf_dir ~= "" and buf_dir or vim.fn.getcwd()))
 	local output_file = output_dir .. "/local.settings.json"
 
 	local function save_and_open()

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -131,7 +131,6 @@ local function do_fetch(config, app_name, resource_group)
 		end
 	end
 
-	local uv = vim.uv or vim.loop
 	if uv.fs_stat(output_file) then
 		-- Try to load existing file for diff
 		local existing_values = nil

--- a/lua/azure/push.lua
+++ b/lua/azure/push.lua
@@ -6,7 +6,8 @@ local diff = require("azure.diff")
 
 -- Read and parse local.settings.json, returns the Values table or nil on error
 local function load_local_settings(config)
-	local output_dir = vim.fn.expand(config.output_path or vim.fn.getcwd())
+	local buf_dir = vim.fn.expand("%:p:h")
+	local output_dir = vim.fn.expand(config.output_path or (buf_dir ~= "" and buf_dir or vim.fn.getcwd()))
 	local path = output_dir .. "/local.settings.json"
 
 	local uv = vim.uv or vim.loop

--- a/lua/azure/push.lua
+++ b/lua/azure/push.lua
@@ -6,8 +6,12 @@ local diff = require("azure.diff")
 
 -- Read and parse local.settings.json, returns the Values table or nil on error
 local function load_local_settings(config)
+	local uv = vim.uv or vim.loop
 	local buf_dir = vim.fn.expand("%:p:h")
-	local output_dir = vim.fn.expand(config.output_path or (buf_dir ~= "" and buf_dir or vim.fn.getcwd()))
+	if buf_dir == "" or not uv.fs_stat(buf_dir) then
+		buf_dir = vim.fn.getcwd()
+	end
+	local output_dir = vim.fn.expand(config.output_path or buf_dir)
 	local path = output_dir .. "/local.settings.json"
 
 	local uv = vim.uv or vim.loop


### PR DESCRIPTION
## Summary

- Replace `getcwd()` with `vim.fn.expand("%:p:h")` (directory of the active buffer) in both `fetch.lua` and `push.lua`
- Fixes the issue where `local.settings.json` was always written to the project root instead of the folder of the file you have open
- Falls back to `getcwd()` when no buffer is open
- Explicit `output_path` in config still takes precedence

## Test plan

- [ ] Open a file inside a subdirectory (e.g. `MyFunctionApp/MyFunction/SomeFile.cs`)
- [ ] Run `:AzFetchAppSettings` — verify `local.settings.json` is created in `MyFunctionApp/MyFunction/`
- [ ] Run `:AzPushAppSettings` — verify it reads from the same directory
- [ ] Verify `output_path` in config still overrides the buffer directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)