### PR TITLE
Combine diff view and confirmation into a single popup

### DIFF
--- a/lua/azure/diff.lua
+++ b/lua/azure/diff.lua
@@ -33,6 +33,131 @@ function M.compute(local_values, azure_values)
 	return result
 end
 
+-- Show diff in a floating window with built-in confirm prompt.
+-- on_confirm(true) = user chose yes, on_confirm(false) = cancelled/no.
+function M.show_confirm(diff_result, title, prompt, on_confirm, opts)
+	opts = opts or {}
+	local labels = opts.labels or {
+		added      = " + New (local only — will be pushed)",
+		changed    = " ~ Changed",
+		unchanged  = " = Unchanged",
+		azure_only = " - Azure only (will not be changed)",
+	}
+	local changed_labels = opts.changed_labels or {
+		before = "azure",
+		after  = "local",
+	}
+	local swap = opts.swap or false
+
+	local lines = {}
+	local highlights = {}
+
+	local function add(line, hl_group)
+		table.insert(lines, line)
+		if hl_group then
+			table.insert(highlights, { #lines - 1, hl_group })
+		end
+	end
+
+	local function section(label, keys, format_fn, hl_group)
+		if #keys == 0 then return end
+		table.sort(keys)
+		add(label, "Comment")
+		for _, key in ipairs(keys) do
+			for _, l in ipairs(vim.split(format_fn(key), "\n", { plain = true })) do
+				add(l, hl_group)
+			end
+		end
+		add("")
+	end
+
+	add(" " .. (title or "Azure diff"), "Title")
+	add("")
+
+	section(
+		labels.added,
+		vim.tbl_keys(diff_result.added),
+		function(k) return "   " .. (swap and "-" or "+") .. " " .. k .. " = " .. tostring(diff_result.added[k]) end,
+		swap and "DiffDelete" or "DiffAdd"
+	)
+
+	section(
+		labels.changed,
+		vim.tbl_keys(diff_result.changed),
+		function(k)
+			local e = diff_result.changed[k]
+			local before_val = swap and e.local_val or e.azure_val
+			local after_val  = swap and e.azure_val or e.local_val
+			return "   ~ " .. k
+				.. "\n       " .. changed_labels.before .. ": " .. tostring(before_val)
+				.. "\n       " .. changed_labels.after  .. ": " .. tostring(after_val)
+		end,
+		"DiffChange"
+	)
+
+	section(
+		labels.unchanged,
+		vim.tbl_keys(diff_result.unchanged),
+		function(k) return "   = " .. k end,
+		"Comment"
+	)
+
+	section(
+		labels.azure_only,
+		vim.tbl_keys(diff_result.azure_only),
+		function(k) return "   " .. (swap and "+" or "-") .. " " .. k end,
+		swap and "DiffAdd" or "DiffDelete"
+	)
+
+	-- Add confirmation footer
+	add("", nil)
+	add(" " .. (prompt or "Confirm?"), "Title")
+	local footer_line = #lines
+	add("  [y] Yes   [n] No", "Comment")
+
+	local buf = vim.api.nvim_create_buf(false, true)
+	vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+	vim.bo[buf].modifiable = false
+	vim.bo[buf].bufhidden = "wipe"
+
+	for _, hl in ipairs(highlights) do
+		vim.api.nvim_buf_add_highlight(buf, -1, hl[2], hl[1], 0, -1)
+	end
+	vim.api.nvim_buf_add_highlight(buf, -1, "Title", footer_line - 1, 0, -1)
+	vim.api.nvim_buf_add_highlight(buf, -1, "Comment", footer_line, 0, -1)
+
+	local ui = vim.api.nvim_list_uis()[1]
+	local width = math.min(80, ui and ui.width - 4 or 80)
+	local height = math.min(#lines + 2, ui and math.floor(ui.height * 0.8) or 30)
+	local row = ui and math.floor((ui.height - height) / 2) or 5
+	local col = ui and math.floor((ui.width - width) / 2) or 10
+
+	local win = vim.api.nvim_open_win(buf, true, {
+		relative = "editor",
+		width    = width,
+		height   = height,
+		row      = row,
+		col      = col,
+		style    = "minimal",
+		border   = "rounded",
+		noautocmd = true,
+	})
+
+	local function confirm(yes)
+		if vim.api.nvim_win_is_valid(win) then
+			vim.api.nvim_win_close(win, true)
+		end
+		on_confirm(yes)
+	end
+
+	vim.keymap.set("n", "y", function() confirm(true) end,  { buffer = buf, nowait = true })
+	vim.keymap.set("n", "n", function() confirm(false) end, { buffer = buf, nowait = true })
+	vim.keymap.set("n", "q", function() confirm(false) end, { buffer = buf, nowait = true })
+	vim.keymap.set("n", "<Esc>", function() confirm(false) end, { buffer = buf, nowait = true })
+
+	return buf, win
+end
+
 -- Show diff in a scratch buffer split.
 -- opts.labels overrides section headers for context-specific messaging.
 -- Returns buf, win so callers can close it programmatically.

--- a/lua/azure/diff.lua
+++ b/lua/azure/diff.lua
@@ -33,9 +33,9 @@ function M.compute(local_values, azure_values)
 	return result
 end
 
--- Show diff in a floating window with built-in confirm prompt.
--- on_confirm(true) = user chose yes, on_confirm(false) = cancelled/no.
-function M.show_confirm(diff_result, title, prompt, on_confirm, opts)
+-- Shared helper: build lines + highlights from a diff result.
+-- Returns { lines, highlights } where highlights = { { line_index, hl_group }, ... }
+local function build_lines(diff_result, title, opts)
 	opts = opts or {}
 	local labels = opts.labels or {
 		added      = " + New (local only — will be pushed)",
@@ -109,11 +109,21 @@ function M.show_confirm(diff_result, title, prompt, on_confirm, opts)
 		swap and "DiffAdd" or "DiffDelete"
 	)
 
+	return lines, highlights
+end
+
+-- Show diff in a floating window with built-in confirm prompt.
+-- on_confirm(true) = user chose yes, on_confirm(false) = cancelled/no.
+-- Closing the window via any means (keymaps or :close/<C-w>c) always calls on_confirm(false).
+function M.show_confirm(diff_result, title, prompt, on_confirm, opts)
+	local lines, highlights = build_lines(diff_result, title, opts)
+
 	-- Add confirmation footer
-	add("", nil)
-	add(" " .. (prompt or "Confirm?"), "Title")
-	local footer_line = #lines
-	add("  [y] Yes   [n] No", "Comment")
+	table.insert(lines, "")
+	table.insert(lines, " " .. (prompt or "Confirm?"))
+	local footer_prompt_line = #lines - 1
+	table.insert(lines, "  [y] Yes   [n] No")
+	local footer_keys_line = #lines - 1
 
 	local buf = vim.api.nvim_create_buf(false, true)
 	vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
@@ -123,37 +133,50 @@ function M.show_confirm(diff_result, title, prompt, on_confirm, opts)
 	for _, hl in ipairs(highlights) do
 		vim.api.nvim_buf_add_highlight(buf, -1, hl[2], hl[1], 0, -1)
 	end
-	vim.api.nvim_buf_add_highlight(buf, -1, "Title", footer_line - 1, 0, -1)
-	vim.api.nvim_buf_add_highlight(buf, -1, "Comment", footer_line, 0, -1)
+	vim.api.nvim_buf_add_highlight(buf, -1, "Title",   footer_prompt_line, 0, -1)
+	vim.api.nvim_buf_add_highlight(buf, -1, "Comment", footer_keys_line,   0, -1)
 
 	local ui = vim.api.nvim_list_uis()[1]
-	local width = math.min(80, ui and ui.width - 4 or 80)
-	local height = math.min(#lines + 2, ui and math.floor(ui.height * 0.8) or 30)
-	local row = ui and math.floor((ui.height - height) / 2) or 5
-	local col = ui and math.floor((ui.width - width) / 2) or 10
+	local ui_width  = ui and ui.width  or 80
+	local ui_height = ui and ui.height or 30
+	local width  = math.max(20, math.min(80, ui_width - 4))
+	local height = math.max(3,  math.min(#lines + 2, math.floor(ui_height * 0.8)))
+	local row = math.max(0, math.floor((ui_height - height) / 2))
+	local col = math.max(0, math.floor((ui_width  - width)  / 2))
 
 	local win = vim.api.nvim_open_win(buf, true, {
-		relative = "editor",
-		width    = width,
-		height   = height,
-		row      = row,
-		col      = col,
-		style    = "minimal",
-		border   = "rounded",
+		relative  = "editor",
+		width     = width,
+		height    = height,
+		row       = row,
+		col       = col,
+		style     = "minimal",
+		border    = "rounded",
 		noautocmd = true,
 	})
 
+	-- Guard to ensure on_confirm is called at most once
+	local called = false
 	local function confirm(yes)
+		if called then return end
+		called = true
 		if vim.api.nvim_win_is_valid(win) then
 			vim.api.nvim_win_close(win, true)
 		end
 		on_confirm(yes)
 	end
 
-	vim.keymap.set("n", "y", function() confirm(true) end,  { buffer = buf, nowait = true })
-	vim.keymap.set("n", "n", function() confirm(false) end, { buffer = buf, nowait = true })
-	vim.keymap.set("n", "q", function() confirm(false) end, { buffer = buf, nowait = true })
+	vim.keymap.set("n", "y",     function() confirm(true)  end, { buffer = buf, nowait = true })
+	vim.keymap.set("n", "n",     function() confirm(false) end, { buffer = buf, nowait = true })
+	vim.keymap.set("n", "q",     function() confirm(false) end, { buffer = buf, nowait = true })
 	vim.keymap.set("n", "<Esc>", function() confirm(false) end, { buffer = buf, nowait = true })
+
+	-- Catch window closed via :close, <C-w>c, or any other means
+	vim.api.nvim_create_autocmd("BufWipeout", {
+		buffer = buf,
+		once   = true,
+		callback = function() confirm(false) end,
+	})
 
 	return buf, win
 end
@@ -162,78 +185,7 @@ end
 -- opts.labels overrides section headers for context-specific messaging.
 -- Returns buf, win so callers can close it programmatically.
 function M.show(diff_result, title, opts)
-	opts = opts or {}
-	local labels = opts.labels or {
-		added      = " + New (local only — will be pushed)",
-		changed    = " ~ Changed",
-		unchanged  = " = Unchanged",
-		azure_only = " - Azure only (will not be changed)",
-	}
-	local changed_labels = opts.changed_labels or {
-		before = "azure",
-		after  = "local",
-	}
-	local swap = opts.swap or false
-
-	local lines = {}
-	local highlights = {} -- { line_index, hl_group }
-
-	local function add(line, hl_group)
-		table.insert(lines, line)
-		if hl_group then
-			table.insert(highlights, { #lines - 1, hl_group })
-		end
-	end
-
-	local function section(label, keys, format_fn, hl_group)
-		if #keys == 0 then return end
-		table.sort(keys)
-		add(label, "Comment")
-		for _, key in ipairs(keys) do
-			for _, l in ipairs(vim.split(format_fn(key), "\n", { plain = true })) do
-				add(l, hl_group)
-			end
-		end
-		add("")
-	end
-
-	add(" " .. (title or "Azure diff"), "Title")
-	add("")
-
-	section(
-		labels.added,
-		vim.tbl_keys(diff_result.added),
-		function(k) return "   " .. (swap and "-" or "+") .. " " .. k .. " = " .. tostring(diff_result.added[k]) end,
-		swap and "DiffDelete" or "DiffAdd"
-	)
-
-	section(
-		labels.changed,
-		vim.tbl_keys(diff_result.changed),
-		function(k)
-			local e = diff_result.changed[k]
-			local before_val = swap and e.local_val or e.azure_val
-			local after_val  = swap and e.azure_val or e.local_val
-			return "   ~ " .. k
-				.. "\n       " .. changed_labels.before .. ": " .. tostring(before_val)
-				.. "\n       " .. changed_labels.after  .. ": " .. tostring(after_val)
-		end,
-		"DiffChange"
-	)
-
-	section(
-		labels.unchanged,
-		vim.tbl_keys(diff_result.unchanged),
-		function(k) return "   = " .. k end,
-		"Comment"
-	)
-
-	section(
-		labels.azure_only,
-		vim.tbl_keys(diff_result.azure_only),
-		function(k) return "   " .. (swap and "+" or "-") .. " " .. k end,
-		swap and "DiffAdd" or "DiffDelete"
-	)
+	local lines, highlights = build_lines(diff_result, title, opts)
 
 	local buf = vim.api.nvim_create_buf(false, true)
 	vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)

--- a/lua/azure/diff.lua
+++ b/lua/azure/diff.lua
@@ -139,8 +139,10 @@ function M.show_confirm(diff_result, title, prompt, on_confirm, opts)
 	local ui = vim.api.nvim_list_uis()[1]
 	local ui_width  = ui and ui.width  or 80
 	local ui_height = ui and ui.height or 30
-	local width  = math.max(20, math.min(80, ui_width - 4))
-	local height = math.max(3,  math.min(#lines + 2, math.floor(ui_height * 0.8)))
+	local preferred_width  = math.min(80, ui_width - 4)
+	local preferred_height = math.min(#lines + 2, math.floor(ui_height * 0.8))
+	local width  = math.min(ui_width,  math.max(20, preferred_width))
+	local height = math.min(ui_height, math.max(3,  preferred_height))
 	local row = math.max(0, math.floor((ui_height - height) / 2))
 	local col = math.max(0, math.floor((ui_width  - width)  / 2))
 

--- a/lua/azure/fetch.lua
+++ b/lua/azure/fetch.lua
@@ -160,32 +160,33 @@ local function do_fetch(config, app_name, resource_group)
 			-- azure_only = in new Azure, not in existing file  → will be added to local
 			-- swap = true: show existing (local_val) as "before", new Azure (azure_val) as "after"
 			local d = diff.compute(existing_values, local_settings.Values)
-			local _, win = diff.show(d, "Fetch diff: " .. app_name, {
-				labels = {
-					added      = " - Will be removed from local file",
-					changed    = " ~ Will be updated in local file",
-					unchanged  = " = Unchanged",
-					azure_only = " + Will be added to local file",
-				},
-				changed_labels = {
-					before = "existing",
-					after  = "new from Azure",
-				},
-				swap = true,
-			})
-
-			vim.ui.select({ "Yes", "No" }, {
-				prompt = "Apply these changes to " .. output_file .. "?",
-			}, function(choice)
-				diff.close(win)
-				if choice == "Yes" then
-					save_and_open()
-				else
-					vim.notify("Cancelled: file not updated.", vim.log.levels.WARN)
-				end
-			end)
+			diff.show_confirm(
+				d,
+				"Fetch diff: " .. app_name,
+				"Apply these changes to " .. output_file .. "?",
+				function(confirmed)
+					if confirmed then
+						save_and_open()
+					else
+						vim.notify("Cancelled: file not updated.", vim.log.levels.WARN)
+					end
+				end,
+				{
+					labels = {
+						added      = " - Will be removed from local file",
+						changed    = " ~ Will be updated in local file",
+						unchanged  = " = Unchanged",
+						azure_only = " + Will be added to local file",
+					},
+					changed_labels = {
+						before = "existing",
+						after  = "new from Azure",
+					},
+					swap = true,
+				}
+			)
 		else
-			-- Fallback: simple overwrite confirmation
+			-- Fallback: simple overwrite confirmation (no diff available)
 			vim.ui.select({ "Yes", "No" }, {
 				prompt = output_file .. " already exists. Overwrite?",
 			}, function(choice)

--- a/lua/azure/push.lua
+++ b/lua/azure/push.lua
@@ -74,41 +74,40 @@ local function do_push(config, app_name, resource_group)
 		return
 	end
 
-	local _, win = diff.show(d, "Push diff: " .. app_name)
+	diff.show_confirm(
+		d,
+		"Push diff: " .. app_name,
+		"Push " .. vim.tbl_count(to_push) .. " new/changed setting(s) to " .. app_name .. "?",
+		function(confirmed)
+			if not confirmed then
+				vim.notify("Push cancelled.", vim.log.levels.WARN)
+				return
+			end
 
-	vim.ui.select({ "Yes", "No" }, {
-		prompt = "Push " .. vim.tbl_count(to_push) .. " new/changed setting(s) to " .. app_name .. "?",
-	}, function(choice)
-		diff.close(win)
+			vim.notify("Pushing " .. vim.tbl_count(to_push) .. " setting(s) to " .. app_name .. "...", vim.log.levels.INFO)
 
-		if choice ~= "Yes" then
-			vim.notify("Push cancelled.", vim.log.levels.WARN)
-			return
+			local args = {
+				"az", "functionapp", "config", "appsettings", "set",
+				"--name", app_name,
+				"--resource-group", resource_group,
+				"--settings",
+			}
+			for key, value in pairs(to_push) do
+				table.insert(args, key .. "=" .. tostring(value))
+			end
+
+			local result, err = az.run_az_command(args)
+			if not result then
+				vim.notify("Failed to push settings:\n" .. err, vim.log.levels.ERROR)
+				return
+			end
+
+			vim.notify(
+				"Successfully pushed " .. vim.tbl_count(to_push) .. " setting(s) to " .. app_name .. ".",
+				vim.log.levels.INFO
+			)
 		end
-
-		vim.notify("Pushing " .. vim.tbl_count(to_push) .. " setting(s) to " .. app_name .. "...", vim.log.levels.INFO)
-
-		local args = {
-			"az", "functionapp", "config", "appsettings", "set",
-			"--name", app_name,
-			"--resource-group", resource_group,
-			"--settings",
-		}
-		for key, value in pairs(to_push) do
-			table.insert(args, key .. "=" .. tostring(value))
-		end
-
-		local result, err = az.run_az_command(args)
-		if not result then
-			vim.notify("Failed to push settings:\n" .. err, vim.log.levels.ERROR)
-			return
-		end
-
-		vim.notify(
-			"Successfully pushed " .. vim.tbl_count(to_push) .. " setting(s) to " .. app_name .. ".",
-			vim.log.levels.INFO
-		)
-	end)
+	)
 end
 
 -- Main entry point: select resource group and function app, then push


### PR DESCRIPTION
 ## Summary

  - Replaced the split diff window + separate `vim.ui.select` prompt with a single centered floating window that
  shows the diff and confirmation together
  - Applies to both push and fetch flows
  - New `diff.show_confirm()` function handles rendering the diff with `[y] Yes  [n] No` keybindings built in
  (`n`, `q`, `<Esc>` all cancel)

  ## Test plan

  - [ ] Push with changes: confirm floating window shows diff + prompt, `y` pushes, `n`/`q`/`<Esc>` cancels
  - [ ] Fetch with an existing `local.settings.json`: confirm floating window shows diff + prompt, `y` saves, `n`
  cancels
  - [ ] Fetch with a non-parseable `local.settings.json`: fallback overwrite confirmation still works
  - [ ] Fetch when no `local.settings.json` exists yet: file is written directly without prompt
