### PR TITLE
Add plenary test suite and GitHub Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: stable
+
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+PLENARY_PATH ?= /tmp/plenary.nvim
+
+.PHONY: test
+
+$(PLENARY_PATH):
+	git clone --depth=1 https://github.com/nvim-lua/plenary.nvim $(PLENARY_PATH)
+
+test: $(PLENARY_PATH)
+	nvim --headless -u tests/minimal_init.lua \
+		-c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"

--- a/tests/az_spec.lua
+++ b/tests/az_spec.lua
@@ -1,0 +1,103 @@
+local az = require("azure.az")
+
+describe("az.run_az_command", function()
+  local original_system = vim.system
+
+  after_each(function()
+    vim.system = original_system
+  end)
+
+  it("returns stdout on success", function()
+    vim.system = function(_, _opts)
+      return {
+        wait = function()
+          return { code = 0, stdout = "hello\n", stderr = "" }
+        end,
+      }
+    end
+
+    local result, err = az.run_az_command({ "az", "version" })
+    assert.equals("hello\n", result)
+    assert.is_nil(err)
+  end)
+
+  it("returns nil and stderr on non-zero exit code", function()
+    vim.system = function(_, _opts)
+      return {
+        wait = function()
+          return { code = 1, stdout = "", stderr = "az: command not found" }
+        end,
+      }
+    end
+
+    local result, err = az.run_az_command({ "az", "version" })
+    assert.is_nil(result)
+    assert.equals("az: command not found", err)
+  end)
+
+  it("falls back to stdout when stderr is empty on error", function()
+    vim.system = function(_, _opts)
+      return {
+        wait = function()
+          return { code = 1, stdout = "some error in stdout", stderr = "" }
+        end,
+      }
+    end
+
+    local result, err = az.run_az_command({ "az", "version" })
+    assert.is_nil(result)
+    assert.equals("some error in stdout", err)
+  end)
+end)
+
+describe("az.fetch_app_settings", function()
+  local original_system = vim.system
+  local notifications
+
+  before_each(function()
+    notifications = {}
+    vim.notify = function(msg, level)
+      table.insert(notifications, { msg = msg, level = level })
+    end
+  end)
+
+  after_each(function()
+    vim.system = original_system
+  end)
+
+  it("returns a flat key→value table on success", function()
+    local json = vim.json.encode({
+      { name = "FOO", value = "bar" },
+      { name = "BAZ", value = "qux" },
+    })
+    vim.system = function(_, _opts)
+      return { wait = function() return { code = 0, stdout = json, stderr = "" } end }
+    end
+
+    local result = az.fetch_app_settings("my-app", "my-rg")
+    assert.same({ FOO = "bar", BAZ = "qux" }, result)
+    assert.same({}, notifications)
+  end)
+
+  it("returns nil and notifies on az CLI error", function()
+    vim.system = function(_, _opts)
+      return { wait = function() return { code = 1, stdout = "", stderr = "Not logged in" } end }
+    end
+
+    local result = az.fetch_app_settings("my-app", "my-rg")
+    assert.is_nil(result)
+    assert.equals(1, #notifications)
+    assert.equals(vim.log.levels.ERROR, notifications[1].level)
+  end)
+
+  it("returns nil and notifies on invalid JSON", function()
+    vim.system = function(_, _opts)
+      return { wait = function() return { code = 0, stdout = "not json", stderr = "" } end }
+    end
+
+    local result = az.fetch_app_settings("my-app", "my-rg")
+    assert.is_nil(result)
+    assert.equals(1, #notifications)
+    assert.equals(vim.log.levels.ERROR, notifications[1].level)
+  end)
+end)

--- a/tests/diff_spec.lua
+++ b/tests/diff_spec.lua
@@ -1,0 +1,81 @@
+local diff = require("azure.diff")
+
+describe("diff.compute", function()
+  it("returns empty result for empty inputs", function()
+    local result = diff.compute({}, {})
+    assert.same({}, result.added)
+    assert.same({}, result.changed)
+    assert.same({}, result.unchanged)
+    assert.same({}, result.azure_only)
+  end)
+
+  it("detects a key present locally but not in Azure as added", function()
+    local result = diff.compute({ MY_KEY = "hello" }, {})
+    assert.same({ MY_KEY = "hello" }, result.added)
+    assert.same({}, result.changed)
+    assert.same({}, result.unchanged)
+    assert.same({}, result.azure_only)
+  end)
+
+  it("detects a key present in Azure but not locally as azure_only", function()
+    local result = diff.compute({}, { MY_KEY = "hello" })
+    assert.same({}, result.added)
+    assert.same({}, result.changed)
+    assert.same({}, result.unchanged)
+    assert.same({ MY_KEY = "hello" }, result.azure_only)
+  end)
+
+  it("detects matching keys with same value as unchanged", function()
+    local result = diff.compute({ FOO = "bar" }, { FOO = "bar" })
+    assert.same({}, result.added)
+    assert.same({}, result.changed)
+    assert.same({ FOO = "bar" }, result.unchanged)
+    assert.same({}, result.azure_only)
+  end)
+
+  it("detects matching keys with different values as changed", function()
+    local result = diff.compute({ FOO = "local_val" }, { FOO = "azure_val" })
+    assert.same({}, result.added)
+    assert.same({ FOO = { local_val = "local_val", azure_val = "azure_val" } }, result.changed)
+    assert.same({}, result.unchanged)
+    assert.same({}, result.azure_only)
+  end)
+
+  it("compares values as strings (number 42 matches string '42')", function()
+    local result = diff.compute({ PORT = "42" }, { PORT = 42 })
+    assert.same({}, result.changed)
+    assert.same({ PORT = "42" }, result.unchanged)
+  end)
+
+  it("handles a mixed scenario with all four categories", function()
+    local local_vals = {
+      ADDED_KEY   = "new",
+      CHANGED_KEY = "local_value",
+      SAME_KEY    = "same",
+    }
+    local azure_vals = {
+      CHANGED_KEY  = "azure_value",
+      SAME_KEY     = "same",
+      AZURE_KEY    = "only_in_azure",
+    }
+
+    local result = diff.compute(local_vals, azure_vals)
+
+    assert.same({ ADDED_KEY = "new" }, result.added)
+    assert.same({ CHANGED_KEY = { local_val = "local_value", azure_val = "azure_value" } }, result.changed)
+    assert.same({ SAME_KEY = "same" }, result.unchanged)
+    assert.same({ AZURE_KEY = "only_in_azure" }, result.azure_only)
+  end)
+
+  it("handles multiple added keys", function()
+    local result = diff.compute({ A = "1", B = "2", C = "3" }, {})
+    assert.same({ A = "1", B = "2", C = "3" }, result.added)
+    assert.same({}, result.azure_only)
+  end)
+
+  it("handles multiple azure_only keys", function()
+    local result = diff.compute({}, { X = "10", Y = "20" })
+    assert.same({}, result.added)
+    assert.same({ X = "10", Y = "20" }, result.azure_only)
+  end)
+end)

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,11 @@
+local plenary_path = "/tmp/plenary.nvim"
+
+if vim.fn.isdirectory(plenary_path) == 0 then
+  print("Cloning plenary.nvim...")
+  vim.fn.system({ "git", "clone", "--depth=1", "https://github.com/nvim-lua/plenary.nvim", plenary_path })
+end
+
+vim.opt.rtp:prepend(".")
+vim.opt.rtp:prepend(plenary_path)
+
+vim.cmd("runtime plugin/plenary.vim")


### PR DESCRIPTION
## Summary

- Adds **plenary.nvim** as the test runner (de facto standard for Neovim plugins)
- Tests run headlessly inside Neovim via `make test`
- **15 tests** covering the two most testable modules:
  - `tests/diff_spec.lua` — 9 tests for `diff.compute` (pure logic)
  - `tests/az_spec.lua` — 6 tests for `az.run_az_command` and `az.fetch_app_settings` (with mocked `vim.system`)
- GitHub Actions CI runs tests on every push and pull request

## Test plan

- [x] `make test` runs locally — all 15 tests pass
- [x] CI workflow triggers on push to `main` and on pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)